### PR TITLE
Provide a IWebProxy parameter for HttpClient 

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -98,9 +98,11 @@ namespace WebDAVClient
         #endregion
 
 
-        public Client(NetworkCredential credential = null, TimeSpan? uploadTimeout = null)
+        public Client(NetworkCredential credential = null, TimeSpan? uploadTimeout = null, IWebProxy proxy = null)
         {
             var handler = new HttpClientHandler();
+            if (proxy != null && handler.SupportsProxy)
+                handler.Proxy = proxy;
             if (handler.SupportsAutomaticDecompression)
                 handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
             if (credential != null)


### PR DESCRIPTION
Hello,
Filling optionally the HttpClientHandler.Proxy with http proxy and credentials.
This makes this webdav implementation usable with corporate http proxies.

Rgds,
Geoffroy Querol
