### PR TITLE
Improved compatibility to SVN

### DIFF
--- a/WebDAVClient/Helpers/ResponseParser.cs
+++ b/WebDAVClient/Helpers/ResponseParser.cs
@@ -125,6 +125,10 @@ namespace WebDAVClient.Helpers
                             case "ishidden":
                                 itemInfo.IsHidden = true;
                                 break;
+                            case "checked-in":
+                            case "version-controlled-configuration":
+                                reader.Skip();
+                                break;
                             default:
                             {
                                 int a = 0;


### PR DESCRIPTION
This change enables the WabDAVClient to use Apache Subversion as WebDAV server