### PR TITLE
Enable Windows Authentication

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -110,7 +110,10 @@ namespace WebDAVClient
                 handler.Credentials = credential;
                 handler.PreAuthenticate = true;
             }
-
+            else
+            {
+                handler.UseDefaultCredentials = true;
+            }
             _client = new HttpClient(handler);
             _client.DefaultRequestHeaders.ExpectContinue = false;
 


### PR DESCRIPTION
If no NetworkCredential was passed into the constructor, instruct the internal HttpClientHandler to send default credentials with requests.

This is how I solved the question I asked about Windows Authentication (issue #13).
