### PR TITLE
Allow custom headers to be set

### DIFF
--- a/WebDAVClient/IClient.cs
+++ b/WebDAVClient/IClient.cs
@@ -31,6 +31,10 @@ namespace WebDAVClient
         /// </summary>
         string UserAgentVersion { get; set; }
 
+        /// <summary>
+        /// Specify additional headers to be sent with every request
+        /// </summary>
+        ICollection<KeyValuePair<string, string>> CustomHeaders { get; set; }
 
         /// <summary>
         /// List all files present on the server.


### PR DESCRIPTION
I added the capability to add custom headers to every request, which is useful when you're dealing with a custom WebDAV implementation that changes enumeration behaviour depending on certain headers being set