### PR TITLE
Fix HttpHandler did not use ServerCertificateValidationCallback

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -107,6 +107,7 @@ namespace WebDAVClient
         /// Specify the certificates validation logic
         /// </summary>
         public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
+        
         #endregion
 
         public Client(NetworkCredential credential = null, TimeSpan? uploadTimeout = null, IWebProxy proxy = null)
@@ -129,6 +130,7 @@ namespace WebDAVClient
             {
                 handler.UseDefaultCredentials = true;
             }
+            handler.ServerCertificateCustomValidationCallback = ServerCertificateValidation;
 
             var client = new System.Net.Http.HttpClient(handler, disposeHandler: true);
             client.DefaultRequestHeaders.ExpectContinue = false;
@@ -819,13 +821,13 @@ namespace WebDAVClient
 
         #region WebDAV Connection Helpers
 
-        public bool ServerCertificateValidation(object sender, System.Security.Cryptography.X509Certificates.X509Certificate certification, System.Security.Cryptography.X509Certificates.X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        public bool ServerCertificateValidation(HttpRequestMessage requestMessage, System.Security.Cryptography.X509Certificates.X509Certificate certification, System.Security.Cryptography.X509Certificates.X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
             if (ServerCertificateValidationCallback != null)
             {
-                return ServerCertificateValidationCallback(sender, certification, chain, sslPolicyErrors);
+                return ServerCertificateValidationCallback(requestMessage, certification, chain, sslPolicyErrors);
             }
-            return false;
+            return sslPolicyErrors == SslPolicyErrors.None;
         }
         #endregion
 

--- a/WebDAVClient/IClient.cs
+++ b/WebDAVClient/IClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using WebDAVClient.Model;
@@ -38,6 +39,11 @@ namespace WebDAVClient
         /// Specify additional headers to be sent with every request
         /// </summary>
         ICollection<KeyValuePair<string, string>> CustomHeaders { get; set; }
+
+        /// <summary>
+        /// Specify the certificates validation logic
+        /// </summary>
+        RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
 
         /// <summary>
         /// List all files present on the server.


### PR DESCRIPTION
The `Client` class have definitions of `ServerCertificateValidationCallback` and `ServerCertificateValidation()`, but never use them in the internal HttpClientHandler.

This PR fix it, user now can use:
```csharp
var client = new WebDAVClient.Client();
client.ServerCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
```
to customize their own validation codes when connecting to some self-signed certificate WebDAV servers.

Also, this PR pulls `ServerCertificateValidationCallback` up to `IClient` interface.