### PR TITLE
ICredentials for use with CredentialCache

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -109,7 +109,7 @@ namespace WebDAVClient
         public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
         #endregion
 
-        public Client(NetworkCredential credential = null, TimeSpan? uploadTimeout = null, IWebProxy proxy = null)
+        public Client(ICredentials credential = null, TimeSpan? uploadTimeout = null, IWebProxy proxy = null)
         {
             var handler = new HttpClientHandler();
             if (proxy != null && handler.SupportsProxy)


### PR DESCRIPTION
To allow more than one authentication scheme, it is possible to use a [CredentialCache](https://learn.microsoft.com/en-us/dotnet/api/system.net.credentialcache). Like so:

```C#
var auth = new NetworkCredential();
auth.UserName = AuthUsername;
auth.Password = AuthPassword;
if (AuthDomain is not null) {
	auth.Domain = AuthDomain;
}
credentials = new CredentialCache();
credentials.Add(new Uri(servermatch.Value), "Basic", auth);
credentials.Add(new Uri(servermatch.Value), "Ntlm", auth);
credentials.Add(new Uri(servermatch.Value), "Digest", auth);
Client WDC = new Client(credentials, default, myProxy);
```

This pull request changes the type of the credential parameter in the constructor of Client to ICredentials, so you can either pass a NetworkCredential or a CredentialCache.