### PR TITLE
Fix shared HttpClientHandler being disposed twice when uploadTimeout is set

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -136,7 +136,7 @@ namespace WebDAVClient
             System.Net.Http.HttpClient uploadClient = null;
             if (uploadTimeout != null)
             {
-                uploadClient = new System.Net.Http.HttpClient(handler, disposeHandler: true);
+                uploadClient = new System.Net.Http.HttpClient(handler, disposeHandler: false);
                 uploadClient.DefaultRequestHeaders.ExpectContinue = false;
                 uploadClient.Timeout = uploadTimeout.Value;
             }

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,10 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2025 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Added support for .NET 10
-* Dropped support for .NET 9 (STS); supported targets are now .NET 8 (LTS) and .NET 10 (LTS)</PackageReleaseNotes>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
+    <PackageReleaseNotes>* Fixed shared HttpClientHandler being disposed twice when an uploadTimeout is provided</PackageReleaseNotes>
+    <AssemblyVersion>2.5.0.0</AssemblyVersion>
+    <FileVersion>2.5.0.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue

In `Client.cs` (lines 133–142), when an `uploadTimeout` is provided, both `client` and `uploadClient` share the same `HttpClientHandler`, yet both were constructed with `disposeHandler: true`. Disposing either `HttpClient` would dispose the shared handler and corrupt the other client.

## Fix

The upload client is now created with `disposeHandler: false` so the main client remains the sole owner of the shared `HttpClientHandler`.

## Other changes

- Bumped package version from `2.4.0` to `2.5.0`.
- Updated package release notes.