### PR TITLE
Avoid per-item async GetServerUrl call in List()

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -204,6 +204,7 @@ namespace WebDAVClient
                     }
 
                     var listUrl = listUri.ToString();
+                    var listUriPath = listUri.Path;
 
                     var result = new List<Item>(items.Count);
                     foreach (var item in items)
@@ -215,9 +216,11 @@ namespace WebDAVClient
                         }
                         else
                         {
-                            // If it's not the requested parent folder, add it to the result
-                            var fullHref = await GetServerUrl(item.Href, true).ConfigureAwait(false);
-                            if (!string.Equals(fullHref.ToString(), listUrl, StringComparison.CurrentCultureIgnoreCase))
+                            // If it's not the requested parent folder, add it to the result.
+                            // Compare directly against the already-resolved listUri instead of
+                            // calling GetServerUrl per item, which would build a UriBuilder and
+                            // allocate an async state machine for every collection entry.
+                            if (!IsSameAsListUri(item.Href, listUriPath, listUrl))
                             {
                                 result.Add(item);
                             }
@@ -730,6 +733,29 @@ namespace WebDAVClient
         private static bool TryCreateAbsolute(string uriString, out Uri uriResult)
         {
             return Uri.TryCreate(uriString, UriKind.Absolute, out uriResult) && uriResult.Scheme != Uri.UriSchemeFile;
+        }
+
+        // Determines whether an item's Href refers to the same resource as the listed folder URI.
+        // The server may return Hrefs as either absolute URLs or server-relative paths, with or
+        // without a trailing slash. We compare full URLs when absolute, otherwise just the path
+        // component, normalized so a missing trailing slash doesn't cause a false negative.
+        private static bool IsSameAsListUri(string itemHref, string listUriPath, string listUrl)
+        {
+            if (string.IsNullOrEmpty(itemHref))
+                return false;
+
+            if (TryCreateAbsolute(itemHref, out var absolute))
+            {
+                var normalized = absolute.AbsoluteUri;
+                if (!normalized.EndsWith("/", StringComparison.Ordinal))
+                    normalized += "/";
+                return string.Equals(normalized, listUrl, StringComparison.CurrentCultureIgnoreCase);
+            }
+
+            var hrefPath = itemHref;
+            if (!hrefPath.EndsWith("/", StringComparison.Ordinal))
+                hrefPath += "/";
+            return string.Equals(hrefPath, listUriPath, StringComparison.CurrentCultureIgnoreCase);
         }
 
         private async Task<UriBuilder> GetServerUrl(string path, bool appendTrailingSlash)

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.5.1</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,9 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2025 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Fixed shared HttpClientHandler being disposed twice when an uploadTimeout is provided</PackageReleaseNotes>
-    <AssemblyVersion>2.5.0.0</AssemblyVersion>
-    <FileVersion>2.5.0.0</FileVersion>
+    <PackageReleaseNotes>* Improved performance of List() for large collections by avoiding a per-item async GetServerUrl call when filtering out the parent folder</PackageReleaseNotes>
+    <AssemblyVersion>2.5.1.0</AssemblyVersion>
+    <FileVersion>2.5.1.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue

In `Client.cs` `List()` (around line 219), every collection item returned by the server triggered an awaited `GetServerUrl(item.Href, true)` call just to compare the resulting URL against `listUrl`. Each call allocates an async state machine and a `UriBuilder`, so the cost of filtering out the parent folder scales linearly with the number of subdirectories in large directory listings.

## Fix

Compare `item.Href` against the already-resolved `listUri` directly, without constructing a `UriBuilder` per item:

- When the server returns a relative `Href`, it is compared against `listUri.Path` (with a trailing slash normalized in).
- When the server returns an absolute `Href`, the full URL is compared against `listUrl`.

Behavior is preserved (case-insensitive match, trailing-slash normalization).

## Other changes

- Bumped package version `2.5.0` -> `2.5.1`.
- Updated `PackageReleaseNotes`.