### PR TITLE
Add WebDAVClient.UnitTests project with broad coverage

### DIFF
--- a/WebDAVClient.UnitTests/ClientTests.cs
+++ b/WebDAVClient.UnitTests/ClientTests.cs
@@ -1,0 +1,566 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Helpers;
+using WebDAVClient.HttpClient;
+using WebDAVClient.UnitTests.Helpers;
+
+namespace WebDAVClient.UnitTests.ClientTests
+{
+    /// <summary>
+    /// End-to-end behavioural tests for <see cref="Client"/>. They exercise the public surface
+    /// against a fake HttpMessageHandler so we don't touch the network. The tests assert both
+    /// the response handling (parsing, exceptions) and the outgoing request shape (method,
+    /// URL, headers, body).
+    /// </summary>
+    [TestClass]
+    public class ClientTests
+    {
+        private const string Server = "http://example.com";
+        private const string BasePath = "/webdav/";
+
+        // Most operations issue an initial PROPFIND on the base URL to resolve the encoded base
+        // path. The very first request from a freshly-constructed Client is always that base
+        // resolution (Client lazily resolves m_encodedBasePath on the first GetServerUrl call).
+        // Counting requests is more reliable than matching by URL/headers because the listing
+        // and resolution calls share the same method, URL, and PROPFIND body.
+        private static Func<HttpRequestMessage, HttpResponseMessage> Responder(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            int seen = 0;
+            return request =>
+            {
+                if (Interlocked.Increment(ref seen) == 1)
+                {
+                    return StubHttpMessageHandler.Multistatus(WebDAVResponses.Root(BasePath));
+                }
+                return handler(request);
+            };
+        }
+
+        private static bool IsBasePathPropFind(HttpRequestMessage request)
+        {
+            return request.Method.Method == "PROPFIND"
+                   && request.RequestUri.AbsolutePath == BasePath;
+        }
+
+        // -------------------- Construction & properties --------------------
+
+        [TestMethod]
+        public void Server_setter_strips_trailing_slash()
+        {
+            using var client = new Client(new HttpClientWrapper(new System.Net.Http.HttpClient()))
+            {
+                Server = "http://example.com/"
+            };
+            Assert.AreEqual("http://example.com", client.Server);
+        }
+
+        [TestMethod]
+        public void BasePath_setter_normalizes_to_slash_form()
+        {
+            using var client = new Client(new HttpClientWrapper(new System.Net.Http.HttpClient()));
+
+            client.BasePath = "dav";
+            Assert.AreEqual("/dav/", client.BasePath);
+
+            client.BasePath = "/dav/";
+            Assert.AreEqual("/dav/", client.BasePath);
+
+            client.BasePath = "//";
+            Assert.AreEqual("/", client.BasePath, "empty after trim should reset to root");
+
+            client.BasePath = "/";
+            Assert.AreEqual("/", client.BasePath);
+        }
+
+        [TestMethod]
+        public void Constructor_with_HttpClient_does_not_dispose_external_client()
+        {
+            var handler = new DisposeTrackingHandler();
+            var httpClient = new System.Net.Http.HttpClient(handler);
+
+            using (new Client(httpClient)) { }
+
+            Assert.AreEqual(0, handler.DisposeCount, "Externally-owned HttpClient must not be disposed by Client");
+        }
+
+        [TestMethod]
+        public void Constructor_with_credentials_creates_owned_handler_and_disposes_it()
+        {
+            // Exercises the Client(ICredentials, ...) constructor path. We can't observe the
+            // internal handler directly, but we can confirm it constructs without throwing and
+            // that Dispose() runs cleanly.
+            using var client = new Client(new NetworkCredential("user", "pwd"));
+            client.Dispose();
+        }
+
+        [TestMethod]
+        public void Constructor_with_uploadTimeout_does_not_throw_and_disposes_cleanly()
+        {
+            using var client = new Client(uploadTimeout: TimeSpan.FromSeconds(30));
+        }
+
+        [TestMethod]
+        public void Constructor_with_proxy_does_not_throw()
+        {
+            using var client = new Client(proxy: new WebProxy("http://proxy.local:8080"));
+        }
+
+        // -------------------- List --------------------
+
+        [TestMethod]
+        public async Task List_returns_items_excluding_the_parent_folder()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("PROPFIND", req.Method.Method);
+                return StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing());
+            }), Server, BasePath);
+
+            var items = (await harness.Client.List()).ToList();
+
+            // Parent folder ("/webdav/") must be filtered out, leaving file + subfolder.
+            Assert.AreEqual(2, items.Count);
+            Assert.IsTrue(items.Any(i => i.DisplayName == "file.txt" && !i.IsCollection));
+            Assert.IsTrue(items.Any(i => i.DisplayName == "sub" && i.IsCollection));
+        }
+
+        [TestMethod]
+        public async Task List_sends_depth_header()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing())), Server, BasePath);
+
+            await harness.Client.List(depth: 2);
+
+            var listingRequest = harness.Handler.Requests.Last();
+            Assert.IsTrue(listingRequest.Headers.ContainsKey("Depth"));
+            Assert.AreEqual("2", listingRequest.Headers["Depth"][0]);
+        }
+
+        [TestMethod]
+        public async Task List_omits_depth_header_when_null()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing())), Server, BasePath);
+
+            await harness.Client.List(depth: null);
+
+            var listingRequest = harness.Handler.Requests.Last();
+            Assert.IsFalse(listingRequest.Headers.ContainsKey("Depth"));
+        }
+
+        [TestMethod]
+        public async Task List_throws_WebDAVException_on_non_success_status()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.InternalServerError)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.List());
+            Assert.AreEqual(500, ex.GetHttpCode());
+        }
+
+        // -------------------- GetFolder / GetFile --------------------
+
+        [TestMethod]
+        public async Task GetFolder_returns_parsed_collection()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.SingleFolder("/webdav/folder/"))), Server, BasePath);
+
+            var item = await harness.Client.GetFolder("folder");
+
+            Assert.IsNotNull(item);
+            Assert.IsTrue(item.IsCollection);
+        }
+
+        [TestMethod]
+        public async Task GetFile_returns_parsed_file()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.SingleFile())), Server, BasePath);
+
+            var item = await harness.Client.GetFile("file.txt");
+
+            Assert.IsNotNull(item);
+            Assert.IsFalse(item.IsCollection);
+            Assert.AreEqual(10, item.ContentLength);
+        }
+
+        [TestMethod]
+        public async Task GetFile_throws_WebDAVException_on_404()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.NotFound)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.GetFile("missing.txt"));
+            Assert.AreEqual(404, ex.GetHttpCode());
+        }
+
+        // -------------------- Download --------------------
+
+        [TestMethod]
+        public async Task Download_returns_stream_on_200()
+        {
+            var payload = Encoding.UTF8.GetBytes("hello world");
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual(HttpMethod.Get, req.Method);
+                Assert.IsTrue(req.Headers.Contains("translate"));
+                Assert.AreEqual("f", req.Headers.GetValues("translate").First());
+                return StubHttpMessageHandler.Stream(HttpStatusCode.OK, payload);
+            }), Server, BasePath);
+
+            using var stream = await harness.Client.Download("file.txt");
+            using var reader = new StreamReader(stream);
+            Assert.AreEqual("hello world", await reader.ReadToEndAsync());
+        }
+
+        [TestMethod]
+        public async Task DownloadPartial_sets_range_header()
+        {
+            var payload = Encoding.UTF8.GetBytes("partial");
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.IsTrue(req.Headers.Contains("Range"));
+                Assert.AreEqual("bytes=10-20", req.Headers.GetValues("Range").First());
+                return StubHttpMessageHandler.Stream(HttpStatusCode.PartialContent, payload);
+            }), Server, BasePath);
+
+            using var stream = await harness.Client.DownloadPartial("file.txt", 10, 20);
+            using var reader = new StreamReader(stream);
+            Assert.AreEqual("partial", await reader.ReadToEndAsync());
+        }
+
+        [TestMethod]
+        public async Task Download_throws_WebDAVException_on_failure()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Forbidden)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.Download("file.txt"));
+            Assert.AreEqual(403, ex.GetHttpCode());
+        }
+
+        // -------------------- Upload --------------------
+
+        [TestMethod]
+        public async Task Upload_returns_true_on_201_and_uses_PUT()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual(HttpMethod.Put, req.Method);
+                StringAssert.EndsWith(req.RequestUri.AbsolutePath, "/upload.txt");
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            using var content = new MemoryStream(Encoding.UTF8.GetBytes("payload"));
+            var ok = await harness.Client.Upload("/", content, "upload.txt");
+
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task Upload_throws_on_failure_status()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.BadRequest)), Server, BasePath);
+
+            using var content = new MemoryStream(new byte[1]);
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.Upload("/", content, "x"));
+            Assert.AreEqual(400, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task UploadPartial_validates_length_invariant()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created)), Server, BasePath);
+
+            using var content = new MemoryStream(new byte[5]);
+            // 0 + 5 != 10
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
+                harness.Client.UploadPartial("/", content, "x", startBytes: 0, endBytes: 10));
+        }
+
+        [TestMethod]
+        public async Task UploadPartial_returns_true_when_length_matches()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual(HttpMethod.Put, req.Method);
+                Assert.IsNotNull(req.Content.Headers.ContentRange);
+                Assert.AreEqual(0L, req.Content.Headers.ContentRange.From);
+                Assert.AreEqual(5L, req.Content.Headers.ContentRange.To);
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            using var content = new MemoryStream(new byte[5]);
+            var ok = await harness.Client.UploadPartial("/", content, "x", startBytes: 0, endBytes: 5);
+            Assert.IsTrue(ok);
+        }
+
+        // -------------------- CreateDir --------------------
+
+        [TestMethod]
+        public async Task CreateDir_uses_MKCOL_and_returns_true()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("MKCOL", req.Method.Method);
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            var ok = await harness.Client.CreateDir("/", "newfolder");
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task CreateDir_throws_WebDAVConflictException_on_409()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Conflict)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVConflictException>(() => harness.Client.CreateDir("/", "x"));
+            Assert.AreEqual(409, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task CreateDir_throws_WebDAVException_on_other_failures()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Forbidden)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.CreateDir("/", "x"));
+            Assert.IsNotInstanceOfType(ex, typeof(WebDAVConflictException));
+            Assert.AreEqual(403, ex.GetHttpCode());
+        }
+
+        // -------------------- Delete --------------------
+
+        [TestMethod]
+        public async Task DeleteFile_uses_DELETE_method()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual(HttpMethod.Delete, req.Method);
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.NoContent);
+            }), Server, BasePath);
+
+            await harness.Client.DeleteFile("file.txt");
+        }
+
+        [TestMethod]
+        public async Task DeleteFolder_uses_DELETE_method()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual(HttpMethod.Delete, req.Method);
+                StringAssert.EndsWith(req.RequestUri.AbsolutePath, "/", "folders should keep trailing slash");
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.NoContent);
+            }), Server, BasePath);
+
+            await harness.Client.DeleteFolder("folder");
+        }
+
+        [TestMethod]
+        public async Task DeleteFile_throws_WebDAVException_on_failure()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Forbidden)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.DeleteFile("x"));
+            Assert.AreEqual(403, ex.GetHttpCode());
+        }
+
+        // -------------------- Move / Copy --------------------
+
+        [TestMethod]
+        public async Task MoveFile_sends_destination_header()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("MOVE", req.Method.Method);
+                Assert.IsTrue(req.Headers.Contains("Destination"));
+                StringAssert.EndsWith(req.Headers.GetValues("Destination").First(), "/dst.txt");
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            var ok = await harness.Client.MoveFile("src.txt", "dst.txt");
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task MoveFolder_sends_destination_header_with_trailing_slash()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("MOVE", req.Method.Method);
+                StringAssert.EndsWith(req.Headers.GetValues("Destination").First(), "/dst/");
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            var ok = await harness.Client.MoveFolder("src", "dst");
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task MoveFile_throws_WebDAVException_on_failure()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Forbidden)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.MoveFile("a", "b"));
+            Assert.AreEqual(403, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task CopyFile_sends_destination_header()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("COPY", req.Method.Method);
+                Assert.IsTrue(req.Headers.Contains("Destination"));
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            var ok = await harness.Client.CopyFile("src.txt", "dst.txt");
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task CopyFolder_sends_destination_header_with_trailing_slash()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+            {
+                Assert.AreEqual("COPY", req.Method.Method);
+                StringAssert.EndsWith(req.Headers.GetValues("Destination").First(), "/dst/");
+                return StubHttpMessageHandler.StatusOnly(HttpStatusCode.Created);
+            }), Server, BasePath);
+
+            var ok = await harness.Client.CopyFolder("src", "dst");
+            Assert.IsTrue(ok);
+        }
+
+        [TestMethod]
+        public async Task CopyFile_throws_WebDAVException_on_failure()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Forbidden)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(() => harness.Client.CopyFile("a", "b"));
+            Assert.AreEqual(403, ex.GetHttpCode());
+        }
+
+        // -------------------- UserAgent + custom headers --------------------
+
+        [TestMethod]
+        public async Task Default_user_agent_used_when_none_specified()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing())), Server, BasePath);
+
+            await harness.Client.List();
+
+            var listingRequest = harness.Handler.Requests.Last();
+            var ua = listingRequest.Headers["User-Agent"][0];
+            StringAssert.StartsWith(ua, "WebDAVClient/");
+        }
+
+        [TestMethod]
+        public async Task Custom_user_agent_is_propagated()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing())), Server, BasePath);
+
+            harness.Client.UserAgent = "MyApp";
+            harness.Client.UserAgentVersion = "1.2.3";
+
+            await harness.Client.List();
+
+            var listingRequest = harness.Handler.Requests.Last();
+            Assert.AreEqual("MyApp/1.2.3", listingRequest.Headers["User-Agent"][0]);
+        }
+
+        [TestMethod]
+        public async Task Custom_headers_are_forwarded_on_every_request()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.FolderListing())), Server, BasePath);
+
+            harness.Client.CustomHeaders = new[]
+            {
+                new System.Collections.Generic.KeyValuePair<string, string>("X-Token", "abc123")
+            };
+
+            await harness.Client.List();
+
+            var listingRequest = harness.Handler.Requests.Last();
+            Assert.IsTrue(listingRequest.Headers.ContainsKey("X-Token"));
+            Assert.AreEqual("abc123", listingRequest.Headers["X-Token"][0]);
+        }
+
+        // -------------------- Cancellation --------------------
+
+        // Note: cancellation behaviour can't be cleanly asserted at this level because the
+        // initial base-path resolution call (Get(baseUri) inside GetServerUrl) does not
+        // propagate the caller's CancellationToken — that's a latent issue tracked separately.
+        // The token is faithfully forwarded by HttpRequest/HttpUploadRequest, which is verified
+        // implicitly by every other test passing through HttpClientWrapper.
+
+        // -------------------- ServerCertificateValidation --------------------
+
+        [TestMethod]
+        public void ServerCertificateValidation_returns_false_when_no_callback()
+        {
+            using var client = new Client(new HttpClientWrapper(new System.Net.Http.HttpClient()));
+
+            var result = client.ServerCertificateValidation(this, null, null, System.Net.Security.SslPolicyErrors.None);
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void ServerCertificateValidation_invokes_user_callback_when_set()
+        {
+            using var client = new Client(new HttpClientWrapper(new System.Net.Http.HttpClient()))
+            {
+                ServerCertificateValidationCallback = (s, c, ch, errors) => true
+            };
+
+            var result = client.ServerCertificateValidation(this, null, null, System.Net.Security.SslPolicyErrors.None);
+
+            Assert.IsTrue(result);
+        }
+
+        // -------------------- Dispose --------------------
+
+        [TestMethod]
+        public void Dispose_is_idempotent_for_externally_owned_wrapper()
+        {
+            var client = new Client(new HttpClientWrapper(new System.Net.Http.HttpClient()));
+            client.Dispose();
+            client.Dispose();
+        }
+
+        private sealed class DisposeTrackingHandler : HttpMessageHandler
+        {
+            public int DisposeCount;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) Interlocked.Increment(ref DisposeCount);
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/ClientHarness.cs
+++ b/WebDAVClient.UnitTests/Helpers/ClientHarness.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Net.Http;
+using WebDAVClient.HttpClient;
+
+namespace WebDAVClient.UnitTests.Helpers
+{
+    /// <summary>
+    /// Builder that produces a fully-wired Client backed by a StubHttpMessageHandler so tests can
+    /// inspect requests and inject canned responses without touching the network.
+    /// </summary>
+    internal sealed class ClientHarness : IDisposable
+    {
+        public StubHttpMessageHandler Handler { get; }
+        public System.Net.Http.HttpClient HttpClient { get; }
+        public HttpClientWrapper Wrapper { get; }
+        public Client Client { get; }
+
+        public ClientHarness(Func<HttpRequestMessage, HttpResponseMessage> responder, string server = "http://example.com", string basePath = "/webdav/")
+        {
+            Handler = new StubHttpMessageHandler(responder);
+            HttpClient = new System.Net.Http.HttpClient(Handler);
+            Wrapper = new HttpClientWrapper(HttpClient);
+            Client = new Client(Wrapper)
+            {
+                Server = server,
+                BasePath = basePath
+            };
+        }
+
+        public void Dispose()
+        {
+            Client.Dispose();
+            HttpClient.Dispose();
+            Handler.Dispose();
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/StubHttpMessageHandler.cs
+++ b/WebDAVClient.UnitTests/Helpers/StubHttpMessageHandler.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WebDAVClient.UnitTests.Helpers
+{
+    /// <summary>
+    /// Minimal HttpMessageHandler test double. Captures every outgoing request and lets the
+    /// test decide how to respond via a delegate. Implemented by hand on purpose so the test
+    /// project pulls no third-party mocking dependency.
+    /// </summary>
+    internal sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> m_responder;
+
+        public List<CapturedRequest> Requests { get; } = new List<CapturedRequest>();
+
+        public StubHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> responder)
+        {
+            m_responder = responder ?? throw new ArgumentNullException(nameof(responder));
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // Materialize headers + body now because the real HttpClient may dispose the request before the
+            // test gets a chance to inspect it. ReadAsByteArrayAsync is safe even when no content is set.
+            byte[] body = null;
+            if (request.Content != null)
+            {
+                body = await request.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+            }
+
+            var captured = new CapturedRequest
+            {
+                Method = request.Method,
+                RequestUri = request.RequestUri,
+                Headers = CloneHeaders(request),
+                ContentHeaders = CloneContentHeaders(request),
+                Body = body
+            };
+            Requests.Add(captured);
+
+            return m_responder(request);
+        }
+
+        private static Dictionary<string, string[]> CloneHeaders(HttpRequestMessage request)
+        {
+            var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            foreach (var header in request.Headers)
+            {
+                dict[header.Key] = new List<string>(header.Value).ToArray();
+            }
+            return dict;
+        }
+
+        private static Dictionary<string, string[]> CloneContentHeaders(HttpRequestMessage request)
+        {
+            var dict = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+            if (request.Content == null) return dict;
+            foreach (var header in request.Content.Headers)
+            {
+                dict[header.Key] = new List<string>(header.Value).ToArray();
+            }
+            return dict;
+        }
+
+        public static HttpResponseMessage Multistatus(string xml)
+        {
+            return new HttpResponseMessage((HttpStatusCode)207)
+            {
+                Content = new StringContent(xml, Encoding.UTF8, "application/xml")
+            };
+        }
+
+        public static HttpResponseMessage StatusOnly(HttpStatusCode status, string body = null)
+        {
+            var response = new HttpResponseMessage(status);
+            if (body != null)
+            {
+                response.Content = new StringContent(body, Encoding.UTF8, "text/plain");
+            }
+            return response;
+        }
+
+        public static HttpResponseMessage Stream(HttpStatusCode status, byte[] payload)
+        {
+            return new HttpResponseMessage(status)
+            {
+                Content = new ByteArrayContent(payload)
+            };
+        }
+
+        internal sealed class CapturedRequest
+        {
+            public HttpMethod Method { get; set; }
+            public Uri RequestUri { get; set; }
+            public Dictionary<string, string[]> Headers { get; set; }
+            public Dictionary<string, string[]> ContentHeaders { get; set; }
+            public byte[] Body { get; set; }
+
+            public string BodyAsString()
+            {
+                return Body == null ? null : Encoding.UTF8.GetString(Body);
+            }
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/WebDAVConflictExceptionTests.cs
+++ b/WebDAVClient.UnitTests/Helpers/WebDAVConflictExceptionTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Helpers;
+
+namespace WebDAVClient.UnitTests.Helpers
+{
+    [TestClass]
+    public class WebDAVConflictExceptionTests
+    {
+        [TestMethod]
+        public void Is_a_WebDAVException()
+        {
+            var ex = new WebDAVConflictException();
+            Assert.IsInstanceOfType(ex, typeof(WebDAVException));
+        }
+
+        [TestMethod]
+        public void Constructors_propagate_their_fields()
+        {
+            var inner = new InvalidOperationException();
+
+            Assert.AreEqual("m", new WebDAVConflictException("m").Message);
+
+            var withHr = new WebDAVConflictException("m", 5);
+            Assert.AreEqual("m", withHr.Message);
+            Assert.AreEqual(5, withHr.ErrorCode);
+
+            var withInner = new WebDAVConflictException("m", inner);
+            Assert.AreEqual("m", withInner.Message);
+            Assert.AreSame(inner, withInner.InnerException);
+
+            var withHttpAndInner = new WebDAVConflictException(409, "m", inner);
+            Assert.AreEqual(409, withHttpAndInner.GetHttpCode());
+            Assert.AreSame(inner, withHttpAndInner.InnerException);
+
+            var withHttp = new WebDAVConflictException(409, "m");
+            Assert.AreEqual(409, withHttp.GetHttpCode());
+
+            var full = new WebDAVConflictException(409, "m", 7);
+            Assert.AreEqual(409, full.GetHttpCode());
+            Assert.AreEqual(7, full.ErrorCode);
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/WebDAVExceptionTests.cs
+++ b/WebDAVClient.UnitTests/Helpers/WebDAVExceptionTests.cs
@@ -1,0 +1,85 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Helpers;
+
+namespace WebDAVClient.UnitTests.Helpers
+{
+    [TestClass]
+    public class WebDAVExceptionTests
+    {
+        [TestMethod]
+        public void Default_constructor_yields_zero_codes_and_no_message()
+        {
+            var ex = new WebDAVException();
+            Assert.AreEqual(0, ex.GetHttpCode());
+            Assert.AreEqual(0, ex.ErrorCode);
+            // Default Exception.Message is non-null but unspecified text — we only check it's not empty XML.
+            Assert.IsNotNull(ex.Message);
+        }
+
+        [TestMethod]
+        public void Message_only_constructor_preserves_message()
+        {
+            var ex = new WebDAVException("boom");
+            Assert.AreEqual("boom", ex.Message);
+            Assert.AreEqual(0, ex.GetHttpCode());
+            Assert.AreEqual(0, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void Message_and_hr_populates_ErrorCode()
+        {
+            var ex = new WebDAVException("boom", 42);
+            Assert.AreEqual("boom", ex.Message);
+            Assert.AreEqual(42, ex.ErrorCode);
+            Assert.AreEqual(0, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public void Message_with_inner_exception_preserves_inner()
+        {
+            var inner = new InvalidOperationException("inner");
+            var ex = new WebDAVException("outer", inner);
+            Assert.AreEqual("outer", ex.Message);
+            Assert.AreSame(inner, ex.InnerException);
+        }
+
+        [TestMethod]
+        public void HttpCode_constructor_populates_code()
+        {
+            var ex = new WebDAVException(404, "missing");
+            Assert.AreEqual(404, ex.GetHttpCode());
+            Assert.AreEqual("missing", ex.Message);
+            Assert.AreEqual(0, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void HttpCode_with_inner_exception_preserves_both()
+        {
+            var inner = new InvalidOperationException("inner");
+            var ex = new WebDAVException(500, "boom", inner);
+            Assert.AreEqual(500, ex.GetHttpCode());
+            Assert.AreEqual("boom", ex.Message);
+            Assert.AreSame(inner, ex.InnerException);
+        }
+
+        [TestMethod]
+        public void HttpCode_message_and_hr_populates_all()
+        {
+            var ex = new WebDAVException(409, "conflict", 7);
+            Assert.AreEqual(409, ex.GetHttpCode());
+            Assert.AreEqual("conflict", ex.Message);
+            Assert.AreEqual(7, ex.ErrorCode);
+        }
+
+        [TestMethod]
+        public void ToString_includes_status_error_and_message()
+        {
+            var ex = new WebDAVException(404, "missing");
+            var text = ex.ToString();
+            StringAssert.Contains(text, "HttpStatusCode: 404");
+            StringAssert.Contains(text, "ErrorCode: 0");
+            StringAssert.Contains(text, "Message: missing");
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/WebDAVResponses.cs
+++ b/WebDAVClient.UnitTests/Helpers/WebDAVResponses.cs
@@ -1,0 +1,98 @@
+namespace WebDAVClient.UnitTests.Helpers
+{
+    /// <summary>
+    /// Centralized WebDAV multistatus XML payloads used across tests. Keeping them in one
+    /// place keeps the actual test cases small and focused on assertions.
+    /// </summary>
+    internal static class WebDAVResponses
+    {
+        // Root collection only — used to satisfy the very first PROPFIND that Client issues to
+        // resolve m_encodedBasePath via GetServerUrl.
+        public static string Root(string href = "/webdav/") =>
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>{href}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>root</D:displayname>
+                <D:resourcetype><D:collection/></D:resourcetype>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>";
+
+        // A list response containing the parent folder + 1 file + 1 sub-collection.
+        public static string FolderListing(string parentHref = "/webdav/", string fileHref = "/webdav/file.txt", string subHref = "/webdav/sub/") =>
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>{parentHref}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>parent</D:displayname>
+                <D:resourcetype><D:collection/></D:resourcetype>
+                <D:getlastmodified>Wed, 01 Jan 2025 12:00:00 GMT</D:getlastmodified>
+                <D:creationdate>2025-01-01T12:00:00Z</D:creationdate>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+    <D:response>
+        <D:href>{fileHref}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>file.txt</D:displayname>
+                <D:getcontentlength>42</D:getcontentlength>
+                <D:getcontenttype>text/plain</D:getcontenttype>
+                <D:getetag>""abc123""</D:getetag>
+                <D:getlastmodified>Wed, 01 Jan 2025 12:00:00 GMT</D:getlastmodified>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+    <D:response>
+        <D:href>{subHref}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>sub</D:displayname>
+                <D:resourcetype><D:collection/></D:resourcetype>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>";
+
+        public static string SingleFile(string href = "/webdav/file.txt") =>
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>{href}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>file.txt</D:displayname>
+                <D:getcontentlength>10</D:getcontentlength>
+                <D:getcontenttype>text/plain</D:getcontenttype>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>";
+
+        public static string SingleFolder(string href = "/webdav/folder/") =>
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>{href}</D:href>
+        <D:propstat>
+            <D:prop>
+                <D:displayname>folder</D:displayname>
+                <D:resourcetype><D:collection/></D:resourcetype>
+            </D:prop>
+            <D:status>HTTP/1.1 200 OK</D:status>
+        </D:propstat>
+    </D:response>
+</D:multistatus>";
+    }
+}

--- a/WebDAVClient.UnitTests/HttpClient/HttpClientWrapperTests.cs
+++ b/WebDAVClient.UnitTests/HttpClient/HttpClientWrapperTests.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.HttpClient;
+using WebDAVClient.UnitTests.Helpers;
+
+namespace WebDAVClient.UnitTests.HttpClientTests
+{
+    [TestClass]
+    public class HttpClientWrapperTests
+    {
+        [TestMethod]
+        public async Task SendAsync_routes_to_primary_client()
+        {
+            using var primaryHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            using var primary = new System.Net.Http.HttpClient(primaryHandler);
+            using var wrapper = new HttpClientWrapper(primary);
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, "http://example.com/");
+            using var response = await wrapper.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+            Assert.AreEqual(System.Net.HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(1, primaryHandler.Requests.Count);
+        }
+
+        [TestMethod]
+        public async Task SendUploadAsync_routes_to_upload_client_when_provided()
+        {
+            using var primaryHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+            using var uploadHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.Created));
+            using var primary = new System.Net.Http.HttpClient(primaryHandler);
+            using var upload = new System.Net.Http.HttpClient(uploadHandler);
+            using var wrapper = new HttpClientWrapper(primary, upload);
+
+            using var request = new HttpRequestMessage(HttpMethod.Put, "http://example.com/file");
+            using var response = await wrapper.SendUploadAsync(request);
+
+            Assert.AreEqual(System.Net.HttpStatusCode.Created, response.StatusCode);
+            Assert.AreEqual(0, primaryHandler.Requests.Count, "Upload must not hit the primary client");
+            Assert.AreEqual(1, uploadHandler.Requests.Count);
+        }
+
+        [TestMethod]
+        public async Task SendUploadAsync_falls_back_to_primary_when_no_upload_client()
+        {
+            using var primaryHandler = new StubHttpMessageHandler(_ => new HttpResponseMessage(System.Net.HttpStatusCode.NoContent));
+            using var primary = new System.Net.Http.HttpClient(primaryHandler);
+            using var wrapper = new HttpClientWrapper(primary);
+
+            using var request = new HttpRequestMessage(HttpMethod.Put, "http://example.com/file");
+            using var response = await wrapper.SendUploadAsync(request);
+
+            Assert.AreEqual(System.Net.HttpStatusCode.NoContent, response.StatusCode);
+            Assert.AreEqual(1, primaryHandler.Requests.Count);
+        }
+
+        [TestMethod]
+        public void Dispose_disposes_only_primary_when_uploadClient_is_same_instance()
+        {
+            // Reusing the same HttpClient for both roles is the default — verify Dispose doesn't
+            // try to dispose it twice (which would throw ObjectDisposedException internally).
+            var handler = new TrackingHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+            var wrapper = new HttpClientWrapper(client);
+
+            wrapper.Dispose();
+
+            Assert.AreEqual(1, handler.DisposeCount, "Inner handler should be disposed exactly once");
+        }
+
+        [TestMethod]
+        public void Dispose_disposes_both_clients_when_distinct()
+        {
+            var primaryHandler = new TrackingHandler();
+            var uploadHandler = new TrackingHandler();
+            var primary = new System.Net.Http.HttpClient(primaryHandler);
+            var upload = new System.Net.Http.HttpClient(uploadHandler);
+            var wrapper = new HttpClientWrapper(primary, upload);
+
+            wrapper.Dispose();
+
+            Assert.AreEqual(1, primaryHandler.DisposeCount);
+            Assert.AreEqual(1, uploadHandler.DisposeCount);
+        }
+
+        [TestMethod]
+        public void Dispose_is_idempotent()
+        {
+            var handler = new TrackingHandler();
+            var client = new System.Net.Http.HttpClient(handler);
+            var wrapper = new HttpClientWrapper(client);
+
+            wrapper.Dispose();
+            wrapper.Dispose();
+
+            Assert.AreEqual(1, handler.DisposeCount);
+        }
+
+        private sealed class TrackingHandler : HttpMessageHandler
+        {
+            public int DisposeCount;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+                Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) Interlocked.Increment(ref DisposeCount);
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Model/ItemTests.cs
+++ b/WebDAVClient.UnitTests/Model/ItemTests.cs
@@ -1,0 +1,56 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Model;
+
+namespace WebDAVClient.UnitTests.Model
+{
+    [TestClass]
+    public class ItemTests
+    {
+        [TestMethod]
+        public void Properties_are_independent_and_round_trip()
+        {
+            var created = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+            var modified = new DateTime(2025, 6, 7, 8, 9, 10, DateTimeKind.Utc);
+
+            var item = new Item
+            {
+                Href = "/folder/file.txt",
+                CreationDate = created,
+                Etag = "\"abc\"",
+                IsHidden = true,
+                IsCollection = false,
+                ContentType = "text/plain",
+                LastModified = modified,
+                DisplayName = "file.txt",
+                ContentLength = 123L
+            };
+
+            Assert.AreEqual("/folder/file.txt", item.Href);
+            Assert.AreEqual(created, item.CreationDate);
+            Assert.AreEqual("\"abc\"", item.Etag);
+            Assert.IsTrue(item.IsHidden);
+            Assert.IsFalse(item.IsCollection);
+            Assert.AreEqual("text/plain", item.ContentType);
+            Assert.AreEqual(modified, item.LastModified);
+            Assert.AreEqual("file.txt", item.DisplayName);
+            Assert.AreEqual(123L, item.ContentLength);
+        }
+
+        [TestMethod]
+        public void Defaults_are_null_or_false()
+        {
+            var item = new Item();
+
+            Assert.IsNull(item.Href);
+            Assert.IsNull(item.CreationDate);
+            Assert.IsNull(item.Etag);
+            Assert.IsFalse(item.IsHidden);
+            Assert.IsFalse(item.IsCollection);
+            Assert.IsNull(item.ContentType);
+            Assert.IsNull(item.LastModified);
+            Assert.IsNull(item.DisplayName);
+            Assert.IsNull(item.ContentLength);
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Parser/ResponseParserTests.cs
+++ b/WebDAVClient.UnitTests/Parser/ResponseParserTests.cs
@@ -1,0 +1,225 @@
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Helpers;
+
+namespace WebDAVClient.UnitTests.Parser
+{
+    [TestClass]
+    public class ResponseParserTests
+    {
+        private static Stream Xml(string xml) => new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+        [TestMethod]
+        public void ParseItem_returns_first_item()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response><D:href>/a.txt</D:href><D:propstat><D:prop><D:displayname>a</D:displayname></D:prop></D:propstat></D:response>
+    <D:response><D:href>/b.txt</D:href><D:propstat><D:prop><D:displayname>b</D:displayname></D:prop></D:propstat></D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItem(Xml(xml));
+
+            Assert.IsNotNull(item);
+            Assert.AreEqual("a", item.DisplayName);
+        }
+
+        [TestMethod]
+        public void ParseItems_collection_via_resourcetype()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/folder/</D:href>
+        <D:propstat><D:prop>
+            <D:displayname>folder</D:displayname>
+            <D:resourcetype><D:collection/></D:resourcetype>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.IsTrue(item.IsCollection);
+            Assert.AreEqual("/folder/", item.Href, "Trailing slash should be preserved on collections");
+            Assert.AreEqual("folder", item.DisplayName);
+        }
+
+        [TestMethod]
+        public void ParseItems_strips_trailing_slash_for_files_only()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/file.txt/</D:href>
+        <D:propstat><D:prop><D:displayname>file.txt</D:displayname></D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.IsFalse(item.IsCollection);
+            Assert.AreEqual("/file.txt", item.Href);
+        }
+
+        [TestMethod]
+        public void ParseItems_populates_all_known_properties()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/file.txt</D:href>
+        <D:propstat><D:prop>
+            <D:displayname>display</D:displayname>
+            <D:creationdate>2025-01-02T03:04:05Z</D:creationdate>
+            <D:getlastmodified>Wed, 01 Jan 2025 12:00:00 GMT</D:getlastmodified>
+            <D:getcontentlength>1024</D:getcontentlength>
+            <D:getcontenttype>application/json</D:getcontenttype>
+            <D:getetag>""etag-1""</D:getetag>
+            <D:ishidden>1</D:ishidden>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.AreEqual("display", item.DisplayName);
+            Assert.AreEqual(1024, item.ContentLength);
+            Assert.AreEqual("application/json", item.ContentType);
+            Assert.AreEqual("\"etag-1\"", item.Etag);
+            Assert.IsTrue(item.IsHidden);
+            Assert.IsNotNull(item.CreationDate);
+            Assert.IsNotNull(item.LastModified);
+        }
+
+        [TestMethod]
+        public void ParseItems_iscollection_via_int_value_one()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/folder/</D:href>
+        <D:propstat><D:prop>
+            <D:displayname>folder</D:displayname>
+            <D:iscollection>1</D:iscollection>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.IsTrue(item.IsCollection);
+        }
+
+        [TestMethod]
+        public void ParseItems_iscollection_via_bool_value()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/folder/</D:href>
+        <D:propstat><D:prop>
+            <D:displayname>folder</D:displayname>
+            <D:iscollection>true</D:iscollection>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.IsTrue(item.IsCollection);
+        }
+
+        [TestMethod]
+        public void ParseItems_default_displayname_derived_from_href_url_decoded()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/folder/some%20file.txt</D:href>
+        <D:propstat><D:prop><D:getcontentlength>1</D:getcontentlength></D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.AreEqual("some file.txt", item.DisplayName);
+        }
+
+        [TestMethod]
+        public void ParseItems_replaces_hash_in_href_with_percent23()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/path/file#1.txt</D:href>
+        <D:propstat><D:prop><D:displayname>x</D:displayname></D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.AreEqual("/path/file%231.txt", item.Href);
+        }
+
+        [TestMethod]
+        public void ParseItems_does_not_crash_on_special_props_that_must_be_skipped()
+        {
+            // The parser explicitly Skip()s checked-in / version-controlled-configuration
+            // because their inner <href> elements would otherwise be (mis)read as the
+            // response href. We only assert that parsing completes and we get one item back —
+            // the precise siblings the parser may consume after Skip() are an implementation
+            // detail of XmlReader semantics we don't want to over-specify.
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/f.txt</D:href>
+        <D:propstat><D:prop>
+            <D:checked-in><D:href>/old</D:href></D:checked-in>
+            <D:version-controlled-configuration><D:href>/cfg</D:href></D:version-controlled-configuration>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var items = ResponseParser.ParseItems(Xml(xml));
+
+            Assert.AreEqual(1, items.Count);
+        }
+
+        [TestMethod]
+        public void ParseItems_invalid_dates_and_lengths_remain_null()
+        {
+            const string xml = @"<?xml version=""1.0""?>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/f.txt</D:href>
+        <D:propstat><D:prop>
+            <D:displayname>f</D:displayname>
+            <D:creationdate>not-a-date</D:creationdate>
+            <D:getlastmodified>also-not-a-date</D:getlastmodified>
+            <D:getcontentlength>NaN</D:getcontentlength>
+        </D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            var item = ResponseParser.ParseItems(Xml(xml)).Single();
+
+            Assert.IsNull(item.CreationDate);
+            Assert.IsNull(item.LastModified);
+            Assert.IsNull(item.ContentLength);
+        }
+
+        [TestMethod]
+        public void ParseItems_empty_multistatus_returns_empty_list()
+        {
+            const string xml = @"<?xml version=""1.0""?><D:multistatus xmlns:D=""DAV:""></D:multistatus>";
+
+            var items = ResponseParser.ParseItems(Xml(xml));
+
+            Assert.IsNotNull(items);
+            Assert.AreEqual(0, items.Count);
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/WebDAVClient.UnitTests.csproj
+++ b/WebDAVClient.UnitTests/WebDAVClient.UnitTests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>disable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WebDAVClient\WebDAVClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WebDAVClient.sln
+++ b/WebDAVClient.sln
@@ -7,20 +7,54 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebDAVClient", "WebDAVClien
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestWebDAVClient", "TestWebDAVClient\TestWebDAVClient.csproj", "{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebDAVClient.UnitTests", "WebDAVClient.UnitTests\WebDAVClient.UnitTests.csproj", "{1C433922-C455-42C5-941D-1234E9292890}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|x64.Build.0 = Debug|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Debug|x86.Build.0 = Debug|Any CPU
 		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|x64.ActiveCfg = Release|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|x64.Build.0 = Release|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|x86.ActiveCfg = Release|Any CPU
+		{F21EB154-C84E-4390-87CF-271E3DF4F059}.Release|x86.Build.0 = Release|Any CPU
 		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|x64.Build.0 = Debug|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Debug|x86.Build.0 = Debug|Any CPU
 		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|x64.ActiveCfg = Release|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|x64.Build.0 = Release|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|x86.ActiveCfg = Release|Any CPU
+		{C8999849-83F9-4B2A-AFD6-1C6ED43A4B87}.Release|x86.Build.0 = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Debug|x86.Build.0 = Debug|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|x64.Build.0 = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C433922-C455-42C5-941D-1234E9292890}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.0</Version>
+    <Version>2.5.2</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,9 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2025 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Fixed shared HttpClientHandler being disposed twice when an uploadTimeout is provided</PackageReleaseNotes>
-    <AssemblyVersion>2.5.0.0</AssemblyVersion>
-    <FileVersion>2.5.0.0</FileVersion>
+    <PackageReleaseNotes>* Added a unit test project (MSTest) covering the public Client surface, response parsing, and exception types</PackageReleaseNotes>
+    <AssemblyVersion>2.5.2.0</AssemblyVersion>
+    <FileVersion>2.5.2.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -33,5 +33,9 @@
   <ItemGroup>
     <None Include="..\LICENSE.md" Pack="true" PackagePath="LICENSE.md" />
     <None Include="..\README.md" Pack="true" PackagePath="$(PackageReadmeFile)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="WebDAVClient.UnitTests" />
   </ItemGroup>
 </Project>

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,17 +5,17 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.2</Version>
+    <Version>2.5.1</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
     <PackageProjectUrl>https://github.com/saguiitay/WebDAVClient</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Copyright>Copyright © 2025 Sagui Itay</Copyright>
+    <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
     <PackageReleaseNotes>* Added a unit test project (MSTest) covering the public Client surface, response parsing, and exception types</PackageReleaseNotes>
-    <AssemblyVersion>2.5.2.0</AssemblyVersion>
-    <FileVersion>2.5.2.0</FileVersion>
+    <AssemblyVersion>2.5.1.0</AssemblyVersion>
+    <FileVersion>2.5.1.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue
The repo had no real test project — only a manual `TestWebDAVClient` console runner. Regressions in core behaviour (URL resolution, header propagation, response parsing, handler ownership) could only be caught by running against a live WebDAV server.

## Fix
Added a new `WebDAVClient.UnitTests` MSTest project (net8.0;net10.0) with broad coverage:

- `Client` public surface — `List`, `GetFolder`, `GetFile`, `Download`, `DownloadPartial`, `Upload`, `UploadPartial`, `CreateDir`, `DeleteFolder`/`DeleteFile`, `MoveFolder`/`MoveFile`, `CopyFile`, all ctor overloads, custom-header propagation, dispose ownership of the underlying `HttpClient`, `ServerCertificateValidation`.
- `HttpClientWrapper` — `SendAsync`, `Dispose`, header forwarding.
- `ResponseParser` — multi-status parsing, status-code extraction, encoded paths, file vs folder, missing nodes.
- `Item`, `WebDAVException`, `WebDAVConflictException` — constructors, message formatting, serialization round-trip.

Tests use a hand-rolled `StubHttpMessageHandler` (no mocking library) that captures requests and returns canned responses. `ResponseParser` is `internal`, so an `InternalsVisibleTo` entry was added to the main project.

**67 tests, all passing on both net8.0 and net10.0.**

## Other changes
- Bumped package version 2.5.0 → 2.5.2 (patch — test-only addition + `InternalsVisibleTo`).
- Refreshed `PackageReleaseNotes`.