### PR TITLE
Cache MOVE/COPY request body bytes in static fields

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -44,6 +44,8 @@ namespace WebDAVClient
             //"  </prop> " +
             "</propfind>";
         private static readonly byte[] s_propFindRequestContentBytes = Encoding.UTF8.GetBytes(c_propFindRequestContent);
+        private static readonly byte[] s_moveRequestContentBytes = Encoding.UTF8.GetBytes("MOVE");
+        private static readonly byte[] s_copyRequestContentBytes = Encoding.UTF8.GetBytes("COPY");
 
         private IHttpClientWrapper m_httpClientWrapper;
         private readonly bool m_shouldDispose;
@@ -575,8 +577,6 @@ namespace WebDAVClient
 
         private async Task<bool> Move(Uri srcUri, Uri dstUri, CancellationToken cancellationToken = default)
         {
-            const string requestContent = "MOVE";
-
             IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
             {
                 { "Destination", dstUri.ToString() }
@@ -590,7 +590,7 @@ namespace WebDAVClient
                 }
             }
 
-            var response = await HttpRequest(srcUri, m_moveMethod, headers, Encoding.UTF8.GetBytes(requestContent), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = await HttpRequest(srcUri, m_moveMethod, headers, s_moveRequestContentBytes, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.OK &&
                 response.StatusCode != HttpStatusCode.Created)
@@ -603,8 +603,6 @@ namespace WebDAVClient
 
         private async Task<bool> Copy(Uri srcUri, Uri dstUri, CancellationToken cancellationToken = default)
         {
-            const string requestContent = "COPY";
-
             IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
             {
                 { "Destination", dstUri.ToString() }
@@ -618,7 +616,7 @@ namespace WebDAVClient
                 }
             }
 
-            var response = await HttpRequest(srcUri, m_copyMethod, headers, Encoding.UTF8.GetBytes(requestContent), cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = await HttpRequest(srcUri, m_copyMethod, headers, s_copyRequestContentBytes, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.OK &&
                 response.StatusCode != HttpStatusCode.Created)

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.2</Version>
+    <Version>2.5.3</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,9 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: List() no longer awaits GetServerUrl per collection item. The async state machine, string allocations and UriBuilder construction that previously happened once per subdirectory now happen at most once per List() call, making large directory listings noticeably cheaper.</PackageReleaseNotes>
-    <AssemblyVersion>2.5.2.0</AssemblyVersion>
-    <FileVersion>2.5.2.0</FileVersion>
+    <PackageReleaseNotes>* Performance: Move() and Copy() no longer allocate a fresh UTF-8 byte array for the "MOVE"/"COPY" request body on every call. The bytes are cached in static readonly fields, mirroring the existing s_propFindRequestContentBytes pattern.</PackageReleaseNotes>
+    <AssemblyVersion>2.5.3.0</AssemblyVersion>
+    <FileVersion>2.5.3.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue

`Move()` and `Copy()` (Client.cs:593, 621) called `Encoding.UTF8.GetBytes("MOVE")` / `Encoding.UTF8.GetBytes("COPY")` on every invocation, allocating a fresh byte array each time even though the content is a constant 4-byte string.

```csharp
const string requestContent = "MOVE";
// ...
Encoding.UTF8.GetBytes(requestContent) // allocated fresh every call
```

## Fix

Cache the encoded bytes in `private static readonly` fields, mirroring the existing `s_propFindRequestContentBytes` pattern already used in this file:

```csharp
private static readonly byte[] s_moveRequestContentBytes = Encoding.UTF8.GetBytes("MOVE");
private static readonly byte[] s_copyRequestContentBytes = Encoding.UTF8.GetBytes("COPY");
```

`Move()` and `Copy()` now pass these shared buffers to `HttpRequest`. The local `const string requestContent` declarations are removed.

## Other changes

- Bumped package version to `2.5.3` and updated `PackageReleaseNotes`.
- All 67 unit tests pass on both `net8.0` and `net10.0`.
