### PR TITLE
Avoid per-node string allocation in ResponseParser

### DIFF
--- a/WebDAVClient/Helpers/ResponseParser.cs
+++ b/WebDAVClient/Helpers/ResponseParser.cs
@@ -45,108 +45,113 @@ namespace WebDAVClient.Helpers
                 {
                     if (reader.NodeType == XmlNodeType.Element)
                     {
-                        switch (reader.LocalName.ToLower())
+                        var localName = reader.LocalName;
+                        if (string.Equals(localName, "response", StringComparison.OrdinalIgnoreCase))
                         {
-                            case "response":
-                                itemInfo = new Item();
-                                break;
-                            case "href":
-                                if (!reader.IsEmptyElement)
+                            itemInfo = new Item();
+                        }
+                        else if (string.Equals(localName, "href", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                var value = reader.Value;
+                                value = value.Replace("#", "%23");
+                                itemInfo.Href = value;
+                            }
+                        }
+                        else if (string.Equals(localName, "creationdate", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                if (DateTime.TryParse(reader.Value, out var creationDate))
                                 {
-                                    reader.Read();
-                                    var value = reader.Value;
-                                    value = value.Replace("#", "%23");
-                                    itemInfo.Href = value;
+                                    itemInfo.CreationDate = creationDate;
                                 }
-                                break;
-                            case "creationdate":
-                                if (!reader.IsEmptyElement)
+                            }
+                        }
+                        else if (string.Equals(localName, "getlastmodified", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                if (DateTime.TryParse(reader.Value, out var lastModified))
                                 {
-                                    reader.Read();
-                                    if (DateTime.TryParse(reader.Value, out var creationDate))
-                                    {
-                                        itemInfo.CreationDate = creationDate;
-                                    }
+                                    itemInfo.LastModified = lastModified;
                                 }
-                                break;
-                            case "getlastmodified":
-                                if (!reader.IsEmptyElement)
+                            }
+                        }
+                        else if (string.Equals(localName, "displayname", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                itemInfo.DisplayName = reader.Value;
+                            }
+                        }
+                        else if (string.Equals(localName, "getcontentlength", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                if (long.TryParse(reader.Value, out long contentLength))
                                 {
-                                    reader.Read();
-                                    if (DateTime.TryParse(reader.Value, out var lastModified))
-                                    {
-                                        itemInfo.LastModified = lastModified;
-                                    }
+                                    itemInfo.ContentLength = contentLength;
                                 }
-                                break;
-                            case "displayname":
-                                if (!reader.IsEmptyElement)
+                            }
+                        }
+                        else if (string.Equals(localName, "getcontenttype", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                itemInfo.ContentType = reader.Value;
+                            }
+                        }
+                        else if (string.Equals(localName, "getetag", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                itemInfo.Etag = reader.Value;
+                            }
+                        }
+                        else if (string.Equals(localName, "iscollection", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                if (bool.TryParse(reader.Value, out bool isCollection))
                                 {
-                                    reader.Read();
-                                    itemInfo.DisplayName = reader.Value;
+                                    itemInfo.IsCollection = isCollection;
                                 }
-                                break;
-                            case "getcontentlength":
-                                if (!reader.IsEmptyElement)
+                                if (int.TryParse(reader.Value, out int isCollectionInt))
                                 {
-                                    reader.Read();
-                                    if (long.TryParse(reader.Value, out long contentLength))
-                                    {
-                                        itemInfo.ContentLength = contentLength;
-                                    }
+                                    itemInfo.IsCollection = isCollectionInt == 1;
                                 }
-                                break;
-                            case "getcontenttype":
-                                if (!reader.IsEmptyElement)
+                            }
+                        }
+                        else if (string.Equals(localName, "resourcetype", StringComparison.OrdinalIgnoreCase))
+                        {
+                            if (!reader.IsEmptyElement)
+                            {
+                                reader.Read();
+                                if (string.Equals(reader.LocalName, "collection", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    reader.Read();
-                                    itemInfo.ContentType = reader.Value;
+                                    itemInfo.IsCollection = true;
                                 }
-                                break;
-                            case "getetag":
-                                if (!reader.IsEmptyElement)
-                                {
-                                    reader.Read();
-                                    itemInfo.Etag = reader.Value;
-                                }
-                                break;
-                            case "iscollection":
-                                if (!reader.IsEmptyElement)
-                                {
-                                    reader.Read();
-                                    if (bool.TryParse(reader.Value, out bool isCollection))
-                                    {
-                                        itemInfo.IsCollection = isCollection;
-                                    }
-                                    if (int.TryParse(reader.Value, out int isCollectionInt))
-                                    {
-                                        itemInfo.IsCollection = isCollectionInt == 1;
-                                    }
-                                }
-                                break;
-                            case "resourcetype":
-                                if (!reader.IsEmptyElement)
-                                {
-                                    reader.Read();
-                                    var resourceType = reader.LocalName.ToLower();
-                                    if (string.Equals(resourceType, "collection", StringComparison.InvariantCultureIgnoreCase))
-                                    {
-                                        itemInfo.IsCollection = true;
-                                    }
-                                }
-                                break;
-                            case "hidden":
-                            case "ishidden":
-                                {
-                                    itemInfo.IsHidden = true;
-                                    break;
-                                }
-                            case "checked-in":
-                            case "version-controlled-configuration":
-                                {
-                                    reader.Skip();
-                                    break;
-                                }
+                            }
+                        }
+                        else if (string.Equals(localName, "hidden", StringComparison.OrdinalIgnoreCase) ||
+                                 string.Equals(localName, "ishidden", StringComparison.OrdinalIgnoreCase))
+                        {
+                            itemInfo.IsHidden = true;
+                        }
+                        else if (string.Equals(localName, "checked-in", StringComparison.OrdinalIgnoreCase) ||
+                                 string.Equals(localName, "version-controlled-configuration", StringComparison.OrdinalIgnoreCase))
+                        {
+                            reader.Skip();
                         }
                     }
                     else if (reader.NodeType == XmlNodeType.EndElement && 

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.3</Version>
+    <Version>2.5.4</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,9 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: Move() and Copy() no longer allocate a fresh UTF-8 byte array for the "MOVE"/"COPY" request body on every call. The bytes are cached in static readonly fields, mirroring the existing s_propFindRequestContentBytes pattern.</PackageReleaseNotes>
-    <AssemblyVersion>2.5.3.0</AssemblyVersion>
-    <FileVersion>2.5.3.0</FileVersion>
+    <PackageReleaseNotes>* Performance: ResponseParser no longer calls LocalName.ToLower() on every XML element. Element names are now matched with ordinal case-insensitive comparisons, eliminating a per-node string allocation that was amplified for large directory listings.</PackageReleaseNotes>
+    <AssemblyVersion>2.5.4.0</AssemblyVersion>
+    <FileVersion>2.5.4.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue

`ResponseParser.ParseItems` (Helpers/ResponseParser.cs:48) called `reader.LocalName.ToLower()` for every XML element to drive a `switch` on the lowercased name:

```csharp
switch (reader.LocalName.ToLower()) // allocation per node
```

That allocates a new `string` for every element in the response. Large directory listings (PROPFIND multistatus with many `<response>`/`<href>`/`<getlastmodified>`/etc.) multiply this cost, and `ToLower()` is also culture-sensitive.

The same anti-pattern was repeated inside the `resourcetype` branch (`reader.LocalName.ToLower()` then compared against `"collection"` with `InvariantCultureIgnoreCase`).

## Fix

Replace the `switch` with an `if/else if` chain that matches with `string.Equals(localName, "...", StringComparison.OrdinalIgnoreCase)`. The `LocalName` is read once into a local for clarity. Same change applied to the `resourcetype` inner comparison. No allocations per node, and ordinal comparison is faster than culture-aware comparison for ASCII WebDAV element names.

## Other changes

- Bumped package version to `2.5.4` and updated `PackageReleaseNotes`.
- All 67 unit tests pass on both `net8.0` and `net10.0`.
