### PR TITLE
Avoid redundant header dictionary lookup in HttpRequest/HttpUploadRequest

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -660,9 +660,9 @@ namespace WebDAVClient
 
                 if (headers != null)
                 {
-                    foreach (string key in headers.Keys)
+                    foreach (var kvp in headers)
                     {
-                        request.Headers.Add(key, headers[key]);
+                        request.Headers.Add(kvp.Key, kvp.Value);
                     }
                 }
 
@@ -698,9 +698,9 @@ namespace WebDAVClient
 
                 if (headers != null)
                 {
-                    foreach (string key in headers.Keys)
+                    foreach (var kvp in headers)
                     {
-                        request.Headers.Add(key, headers[key]);
+                        request.Headers.Add(kvp.Key, kvp.Value);
                     }
                 }
 

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.4</Version>
+    <Version>2.5.5</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,9 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: ResponseParser no longer calls LocalName.ToLower() on every XML element. Element names are now matched with ordinal case-insensitive comparisons, eliminating a per-node string allocation that was amplified for large directory listings.</PackageReleaseNotes>
-    <AssemblyVersion>2.5.4.0</AssemblyVersion>
-    <FileVersion>2.5.4.0</FileVersion>
+    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.</PackageReleaseNotes>
+    <AssemblyVersion>2.5.5.0</AssemblyVersion>
+    <FileVersion>2.5.5.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Issue

`HttpRequest` and `HttpUploadRequest` (Client.cs:663, 701) iterated `headers.Keys` and then indexed back into the dictionary for every header, performing two dictionary lookups per entry:

```csharp
foreach (string key in headers.Keys)
{
    request.Headers.Add(key, headers[key]); // redundant lookup
}
```

## Fix

Iterate the dictionary directly as `KeyValuePair<string, string>` and use `kvp.Key` / `kvp.Value`:

```csharp
foreach (var kvp in headers)
{
    request.Headers.Add(kvp.Key, kvp.Value);
}
```

`IDictionary<string, string>` already implements `IEnumerable<KeyValuePair<string, string>>`, so no API change is needed and no re-hashing per entry occurs.

## Other changes

- Bumped package version to `2.5.5` and updated `PackageReleaseNotes`.
- All 67 unit tests pass on both `net8.0` and `net10.0`.
