### PR TITLE
Avoid per-call header dictionary copy of CustomHeaders

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -170,18 +170,13 @@ namespace WebDAVClient
             var listUri = await GetServerUrl(path, true).ConfigureAwait(false);
 
             // Depth header: http://webdav.org/specs/rfc4918.html#rfc.section.9.1.4
-            IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0));
+            IDictionary<string, string> headers = null;
             if (depth != null)
             {
-                headers.Add("Depth", depth.ToString());
-            }
-
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
+                headers = new Dictionary<string, string>(1)
                 {
-                    headers.Add(keyValuePair);
-                }
+                    { "Depth", depth.ToString() }
+                };
             }
 
             HttpResponseMessage response = null;
@@ -264,17 +259,10 @@ namespace WebDAVClient
         /// <returns>A stream with the content of the downloaded file</returns>
         public Task<Stream> Download(string remoteFilePath, CancellationToken cancellationToken = default)
         {
-            var headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
+            var headers = new Dictionary<string, string>(1)
             {
                 { "translate", "f" }
             };
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair.Key, keyValuePair.Value);
-                }
-            }
             return DownloadFile(remoteFilePath, headers, cancellationToken);
         }
 
@@ -287,18 +275,11 @@ namespace WebDAVClient
         /// <returns>A stream with the partial content of the downloaded file</returns>
         public Task<Stream> DownloadPartial(string remoteFilePath, long startBytes, long endBytes, CancellationToken cancellationToken = default)
         {
-            var headers = new Dictionary<string, string>(2 + (CustomHeaders?.Count ?? 0))
+            var headers = new Dictionary<string, string>(2)
             { 
                 { "translate", "f" }, 
                 { "Range", "bytes=" + startBytes + "-" + endBytes } 
             };
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair.Key, keyValuePair.Value);
-                }
-            }
             return DownloadFile(remoteFilePath, headers, cancellationToken);
         }
 
@@ -314,20 +295,11 @@ namespace WebDAVClient
             // Should not have a trailing slash.
             var uploadUri = await GetServerUrl(remoteFilePath.TrimEnd('/') + "/" + name.TrimStart('/'), false).ConfigureAwait(false);
 
-            IDictionary<string, string> headers = new Dictionary<string, string>(CustomHeaders?.Count ?? 0);
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
-
             HttpResponseMessage response = null;
 
             try
             {
-                response = await HttpUploadRequest(uploadUri.Uri, HttpMethod.Put, content, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+                response = await HttpUploadRequest(uploadUri.Uri, HttpMethod.Put, content, null, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (response.StatusCode != HttpStatusCode.OK &&
                     response.StatusCode != HttpStatusCode.NoContent &&
@@ -395,20 +367,11 @@ namespace WebDAVClient
             // Should not have a trailing slash.
             var dirUri = await GetServerUrl(remotePath.TrimEnd('/') + "/" + name.TrimStart('/'), false).ConfigureAwait(false);
 
-            IDictionary<string, string> headers = new Dictionary<string, string>(CustomHeaders?.Count ?? 0);
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
-
             HttpResponseMessage response = null;
 
             try
             {
-                response = await HttpRequest(dirUri.Uri, m_mkColMethod, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+                response = await HttpRequest(dirUri.Uri, m_mkColMethod, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 if (response.StatusCode == HttpStatusCode.Conflict)
                     throw new WebDAVConflictException((int) response.StatusCode, "Failed creating folder.");
@@ -511,16 +474,7 @@ namespace WebDAVClient
         #region Private methods
         private async Task Delete(Uri listUri, CancellationToken cancellationToken = default)
         {
-            IDictionary<string, string> headers = new Dictionary<string, string>(CustomHeaders?.Count ?? 0);
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
-
-            var response = await HttpRequest(listUri, HttpMethod.Delete, headers, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var response = await HttpRequest(listUri, HttpMethod.Delete, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (response.StatusCode != HttpStatusCode.OK &&
                 response.StatusCode != HttpStatusCode.NoContent)
@@ -532,18 +486,10 @@ namespace WebDAVClient
         private async Task<Item> Get(Uri listUri, CancellationToken cancellationToken = default)
         {
             // Depth header: http://webdav.org/specs/rfc4918.html#rfc.section.9.1.4
-            IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
+            IDictionary<string, string> headers = new Dictionary<string, string>(1)
             {
                 { "Depth", "0" }
             };
-
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
 
             HttpResponseMessage response = null;
 
@@ -577,18 +523,10 @@ namespace WebDAVClient
 
         private async Task<bool> Move(Uri srcUri, Uri dstUri, CancellationToken cancellationToken = default)
         {
-            IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
+            IDictionary<string, string> headers = new Dictionary<string, string>(1)
             {
                 { "Destination", dstUri.ToString() }
             };
-
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
 
             var response = await HttpRequest(srcUri, m_moveMethod, headers, s_moveRequestContentBytes, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -603,18 +541,10 @@ namespace WebDAVClient
 
         private async Task<bool> Copy(Uri srcUri, Uri dstUri, CancellationToken cancellationToken = default)
         {
-            IDictionary<string, string> headers = new Dictionary<string, string>(1 + (CustomHeaders?.Count ?? 0))
+            IDictionary<string, string> headers = new Dictionary<string, string>(1)
             {
                 { "Destination", dstUri.ToString() }
             };
-
-            if (CustomHeaders != null)
-            {
-                foreach (var keyValuePair in CustomHeaders)
-                {
-                    headers.Add(keyValuePair);
-                }
-            }
 
             var response = await HttpRequest(srcUri, m_copyMethod, headers, s_copyRequestContentBytes, cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -666,6 +596,14 @@ namespace WebDAVClient
                     }
                 }
 
+                if (CustomHeaders != null)
+                {
+                    foreach (var kvp in CustomHeaders)
+                    {
+                        request.Headers.Add(kvp.Key, kvp.Value);
+                    }
+                }
+
                 // Need to send along content?
                 if (content != null)
                 {
@@ -699,6 +637,14 @@ namespace WebDAVClient
                 if (headers != null)
                 {
                     foreach (var kvp in headers)
+                    {
+                        request.Headers.Add(kvp.Key, kvp.Value);
+                    }
+                }
+
+                if (CustomHeaders != null)
+                {
+                    foreach (var kvp in CustomHeaders)
                     {
                         request.Headers.Add(kvp.Key, kvp.Value);
                     }

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -13,7 +13,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.</PackageReleaseNotes>
+    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
+* Performance: CustomHeaders are no longer copied into a per-call merged dictionary. HttpRequest/HttpUploadRequest now iterate CustomHeaders directly, eliminating one Dictionary allocation and one extra iteration per request.</PackageReleaseNotes>
     <AssemblyVersion>2.5.5.0</AssemblyVersion>
     <FileVersion>2.5.5.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Issue

> 6. CustomHeaders Copied Into a New Dictionary on Every Request (Client.cs — all public methods)
>
> Every public API method creates a new `Dictionary<string, string>`, copies `CustomHeaders` into it, then passes it to `HttpRequest`, which iterates it again to add headers to the request. This is two iterations and one unnecessary allocation per call.

## Fix

`HttpRequest` and `HttpUploadRequest` now iterate `CustomHeaders` directly off the `Client` instance, alongside the small method-specific headers dictionary. Public methods no longer build a merged copy:

- Method-specific dicts are now sized to just the entries they actually add (`Depth`, `Destination`, `translate`, `Range`).
- Methods with **no** method-specific headers (`Upload`, `CreateDir`, `Delete`) now pass `null` instead of allocating an empty merged dict.
- Header ordering at the wire is preserved: method-specific headers are added first, then `CustomHeaders` — same order the previous merged dict produced.

Net result: one fewer `Dictionary` allocation and one fewer header iteration per request, with no behavior change.

## Other changes

- Added a bullet to `<PackageReleaseNotes>` for the upcoming 2.6 release.
- **No version bump** — accumulates on `version-2.6`.
- All 67 unit tests pass on net8.0 and net10.0.