### PR TITLE
Use OrdinalIgnoreCase for parent-folder URL comparison in List()

### DIFF
--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -222,7 +222,7 @@ namespace WebDAVClient
                             // top of this method, so the synchronous helper is safe to use here
                             // and avoids the per-item async state machine allocation.
                             var fullHref = BuildServerUrl(item.Href, true);
-                            if (!string.Equals(fullHref.ToString(), listUrl, StringComparison.CurrentCultureIgnoreCase))
+                            if (!string.Equals(fullHref.ToString(), listUrl, StringComparison.OrdinalIgnoreCase))
                             {
                                 result.Add(item);
                             }

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -13,7 +13,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.</PackageReleaseNotes>
+    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
+* Bug fix / performance: List() now compares the parent-folder URL using StringComparison.OrdinalIgnoreCase instead of CurrentCultureIgnoreCase. URLs are not locale-sensitive, so this avoids both the slower culture-aware comparison and potential wrong results in locales like Turkish (the dotted/dotless 'I' issue).</PackageReleaseNotes>
     <AssemblyVersion>2.5.5.0</AssemblyVersion>
     <FileVersion>2.5.5.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Issue

> 7. `StringComparison.CurrentCultureIgnoreCase` for URL Comparison (Client.cs:220)
>
> URL comparisons should use `OrdinalIgnoreCase`, not `CurrentCultureIgnoreCase`. The latter applies locale-specific rules (slower and can give wrong results for URLs in certain locales).
>
> `if (!string.Equals(fullHref.ToString(), listUrl, StringComparison.CurrentCultureIgnoreCase))`

## Fix

Changed the comparison in `Client.List` (used to filter out the requested parent folder from the result set) from `StringComparison.CurrentCultureIgnoreCase` to `StringComparison.OrdinalIgnoreCase`. URLs are byte-level identifiers, not natural-language text, so ordinal comparison is both faster and avoids locale-specific casing pitfalls (e.g. the Turkish dotted/dotless 'I').

## Other changes

- Added a bullet to `<PackageReleaseNotes>` for the upcoming 2.6 release.
- **No version bump** — accumulates on `version-2.6`.
- All 67 unit tests pass on net8.0 and net10.0.