### PR TITLE
Harden ResponseParser XmlReaderSettings against XXE attacks

### DIFF
--- a/WebDAVClient.UnitTests/Parser/ResponseParserTests.cs
+++ b/WebDAVClient.UnitTests/Parser/ResponseParserTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using WebDAVClient.Helpers;
 
@@ -209,6 +210,38 @@ namespace WebDAVClient.UnitTests.Parser
             Assert.IsNull(item.CreationDate);
             Assert.IsNull(item.LastModified);
             Assert.IsNull(item.ContentLength);
+        }
+
+        [TestMethod]
+        public void XmlReaderSettings_explicitly_hardens_against_xxe()
+        {
+            // Defense-in-depth: even though modern .NET defaults DtdProcessing to Prohibit,
+            // the parser must set it explicitly so that runtimes with different defaults
+            // (notably Mono, which this library supports) are also safe from XXE attacks
+            // coming from a malicious or compromised WebDAV server.
+            // Note: XmlReaderSettings.XmlResolver is set-only and cannot be asserted here;
+            // ParseItems_rejects_xml_with_doctype_declaration covers the runtime behavior.
+            Assert.AreEqual(DtdProcessing.Prohibit, ResponseParser.XmlReaderSettings.DtdProcessing,
+                "DtdProcessing must be explicitly set to Prohibit to block external-entity attacks.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(XmlException))]
+        public void ParseItems_rejects_xml_with_doctype_declaration()
+        {
+            // A malicious WebDAV server could try to exfiltrate local files or trigger SSRF
+            // via an external entity. With DtdProcessing = Prohibit, the parser must throw
+            // before any entity resolution can happen.
+            const string xml = @"<?xml version=""1.0""?>
+<!DOCTYPE foo [ <!ENTITY xxe SYSTEM ""file:///etc/passwd""> ]>
+<D:multistatus xmlns:D=""DAV:"">
+    <D:response>
+        <D:href>/&xxe;.txt</D:href>
+        <D:propstat><D:prop><D:displayname>x</D:displayname></D:prop></D:propstat>
+    </D:response>
+</D:multistatus>";
+
+            ResponseParser.ParseItems(Xml(xml));
         }
 
         [TestMethod]

--- a/WebDAVClient/Helpers/ResponseParser.cs
+++ b/WebDAVClient/Helpers/ResponseParser.cs
@@ -25,6 +25,8 @@ namespace WebDAVClient.Helpers
 
         internal static XmlReaderSettings XmlReaderSettings = new XmlReaderSettings
         {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
             IgnoreComments = true,
             IgnoreProcessingInstructions = true,
             IgnoreWhitespace = true

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -14,8 +14,9 @@
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
     <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
-* Bug fix / performance: List() now compares the parent-folder URL using StringComparison.OrdinalIgnoreCase instead of CurrentCultureIgnoreCase. URLs are not locale-sensitive, so this avoids both the slower culture-aware comparison and potential wrong results in locales like Turkish (the dotted/dotless 'I' issue).</PackageReleaseNotes>
-* Performance: CustomHeaders are no longer copied into a per-call merged dictionary. HttpRequest/HttpUploadRequest now iterate CustomHeaders directly, eliminating one Dictionary allocation and one extra iteration per request.</PackageReleaseNotes>
+* Bug fix / performance: List() now compares the parent-folder URL using StringComparison.OrdinalIgnoreCase instead of CurrentCultureIgnoreCase. URLs are not locale-sensitive, so this avoids both the slower culture-aware comparison and potential wrong results in locales like Turkish (the dotted/dotless 'I' issue).
+* Performance: CustomHeaders are no longer copied into a per-call merged dictionary. HttpRequest/HttpUploadRequest now iterate CustomHeaders directly, eliminating one Dictionary allocation and one extra iteration per request.
+* Security: ResponseParser's XmlReaderSettings now explicitly sets DtdProcessing = Prohibit and XmlResolver = null to harden against XXE (XML External Entity) attacks from malicious or compromised WebDAV servers. Defends against arbitrary file disclosure, SSRF, and "billion laughs" denial-of-service on runtimes (e.g. Mono) where the .NET defaults may differ.</PackageReleaseNotes>
     <AssemblyVersion>2.5.5.0</AssemblyVersion>
     <FileVersion>2.5.5.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Issue

Reported critical security issue in `WebDAVClient/Helpers/ResponseParser.cs` (lines 26–31):

The static `XmlReaderSettings` used for parsing PROPFIND multistatus responses did not explicitly set `DtdProcessing = DtdProcessing.Prohibit` or `XmlResolver = null`. Because WebDAV responses come from a remote (and possibly malicious or compromised) server, a crafted XML payload with a DOCTYPE / external entity could enable:

- Arbitrary local-file disclosure on the client
- Server-Side Request Forgery (SSRF) from the client
- Denial-of-Service via `billion laughs` entity expansion

While .NET 4.5.2+ defaults `DtdProcessing` to `Prohibit`, this is not guaranteed across all runtimes the library supports (notably Mono), so explicit hardening is required.

## Fix

In `ResponseParser.XmlReaderSettings`, explicitly set:

- `DtdProcessing = DtdProcessing.Prohibit`
- `XmlResolver = null`

The other parser behavior is unchanged.

## Tests

Two regression tests added to `WebDAVClient.UnitTests/Parser/ResponseParserTests.cs`:

- `XmlReaderSettings_explicitly_hardens_against_xxe` — asserts the static settings instance has `DtdProcessing == Prohibit`. (`XmlResolver` is set-only on `XmlReaderSettings` and cannot be asserted directly.)
- `ParseItems_rejects_xml_with_doctype_declaration` — feeds a payload containing `<!DOCTYPE ... <!ENTITY xxe SYSTEM ""file:///etc/passwd"">>` to `ParseItems` and asserts it throws `XmlException` before any entity resolution.

Note: on the currently targeted runtimes (net8.0 / net10.0) the .NET defaults already happen to be safe, so these tests pass even without the production fix. They serve as a configuration-guard against regressions (e.g. someone explicitly opting in to `DtdProcessing.Parse` later) and as documented intent for non-default runtimes like Mono where the fix is genuinely load-bearing.

Full suite: `dotnet test` — 69 / 69 passed on both net8.0 and net10.0.

## Other changes

- Added a release-notes bullet under the upcoming `version-2.6` entry in `WebDAVClient.csproj`.
- **No version bump** — accumulates on the `version-2.6` branch.
- Fixed a pre-existing malformed duplicate `</PackageReleaseNotes>` close tag in the same element (the file was syntactically broken XML before this PR).