### PR TITLE
Improve XML documentation on IClient

### DIFF
--- a/WebDAVClient/IClient.cs
+++ b/WebDAVClient/IClient.cs
@@ -42,28 +42,43 @@ namespace WebDAVClient
         /// <summary>
         /// List all files present on the server.
         /// </summary>
-        /// <param name="path">List only files in this path</param>
-        /// <param name="depth">Recursion depth</param>
-        /// <returns>A list of files (entries without a trailing slash) and directories (entries with a trailing slash)</returns>
+        /// <param name="path">List only files in this path. Defaults to <c>/</c> (the configured base path).</param>
+        /// <param name="depth">
+        /// PROPFIND <c>Depth</c> header value. <c>0</c> requests the resource itself only,
+        /// <c>1</c> (the default) requests the resource and its immediate children, and
+        /// <c>null</c> requests infinite depth (<c>Depth: infinity</c>) — note that many
+        /// servers reject infinite-depth PROPFIND requests on collections.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A list of files (entries without a trailing slash) and directories (entries with a trailing slash).</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<IEnumerable<Item>> List(string path = "/", int? depth = 1, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get folder information from the server.
         /// </summary>
-        /// <returns>An item representing the retrieved folder</returns>
+        /// <param name="path">Path of the folder on the server. Defaults to <c>/</c> (the configured base path).</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An item representing the retrieved folder.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<Item> GetFolder(string path = "/", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get file information from the server.
         /// </summary>
-        /// <returns>An item representing the retrieved file</returns>
+        /// <param name="path">Path and filename of the file on the server. Defaults to <c>/</c> (the configured base path).</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>An item representing the retrieved file.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<Item> GetFile(string path = "/", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Download a file from the server
         /// </summary>
         /// <param name="remoteFilePath">Source path and filename of the file on the server</param>
-        /// <returns>A stream with the content of the downloaded file</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A stream with the content of the downloaded file. The caller owns the stream and must dispose it.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<Stream> Download(string remoteFilePath, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -72,16 +87,20 @@ namespace WebDAVClient
         /// <param name="remoteFilePath">Source path and filename of the file on the server</param>
         /// <param name="startBytes">Start bytes of content</param>
         /// <param name="endBytes">End bytes of content</param>
-        /// <returns>A stream with the partial content of the downloaded file</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A stream with the partial content of the downloaded file. The caller owns the stream and must dispose it.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<Stream> DownloadPartial(string remoteFilePath, long startBytes, long endBytes, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Upload a file to the server
         /// </summary>
-        /// <param name="remoteFilePath">Source path and filename of the file on the server</param>
-        /// <param name="content"></param>
-        /// <param name="name"></param>
-        /// <returns>True if the file was uploaded successfully. False otherwise</returns>
+        /// <param name="remoteFilePath">Target directory path on the server (excluding the filename) where the file will be created.</param>
+        /// <param name="content">The stream containing the file content to upload. Must be readable and positioned at the start of the data to send.</param>
+        /// <param name="name">The target filename to create under <paramref name="remoteFilePath"/>.</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the file was uploaded successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> Upload(string remoteFilePath, Stream content, string name, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -92,7 +111,9 @@ namespace WebDAVClient
         /// <param name="name">The target filename. The file must exist on the server</param>
         /// <param name="startBytes">StartByte on the target file</param>
         /// <param name="endBytes">EndByte on the target file</param>
-        /// <returns>True if the file part was uploaded successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the file part was uploaded successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> UploadPartial(string remoteFilePath, Stream content, string name, long startBytes, long endBytes, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -100,17 +121,26 @@ namespace WebDAVClient
         /// </summary>
         /// <param name="remotePath">Destination path of the directory on the server</param>
         /// <param name="name">The name of the folder to create</param>
-        /// <returns>True if the folder was created successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the folder was created successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVConflictException">Thrown when the server returns 409 (Conflict), typically because a parent path is missing.</exception>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns any other non-success status.</exception>
         Task<bool> CreateDir(string remotePath, string name, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a folder from the server.
         /// </summary>
+        /// <param name="path">Path of the folder on the server. Defaults to <c>/</c> (the configured base path).</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task DeleteFolder(string path = "/", CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Deletes a file from the server.
         /// </summary>
+        /// <param name="path">Path and filename of the file on the server. Defaults to <c>/</c> (the configured base path).</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task DeleteFile(string path = "/", CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -118,7 +148,9 @@ namespace WebDAVClient
         /// </summary>
         /// <param name="srcFolderPath">Source path of the folder on the server</param>
         /// <param name="dstFolderPath">Destination path of the folder on the server</param>
-        /// <returns>True if the folder was moved successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the folder was moved successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> MoveFolder(string srcFolderPath, string dstFolderPath, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -126,7 +158,9 @@ namespace WebDAVClient
         /// </summary>
         /// <param name="srcFilePath">Source path and filename of the file on the server</param>
         /// <param name="dstFilePath">Destination path and filename of the file on the server</param>
-        /// <returns>True if the file was moved successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the file was moved successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> MoveFile(string srcFilePath, string dstFilePath, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -134,7 +168,9 @@ namespace WebDAVClient
         /// </summary>
         /// <param name="srcFolderPath">Source path of the folder on the server</param>
         /// <param name="dstFolderPath">Destination path of the folder on the server</param>
-        /// <returns>True if the folder was copied successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the folder was copied successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> CopyFolder(string srcFolderPath, string dstFolderPath, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -142,7 +178,9 @@ namespace WebDAVClient
         /// </summary>
         /// <param name="srcFilePath">Source path and filename of the file on the server</param>
         /// <param name="dstFilePath">Destination path and filename of the file on the server</param>
-        /// <returns>True if the file was copied successfully. False otherwise</returns>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>True if the file was copied successfully. False otherwise.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> CopyFile(string srcFilePath, string dstFilePath, CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
## Issue

Reported gaps in the XML documentation on the public `IClient` interface:

- `GetFolder` and `GetFile` were missing `<param name=""path"">` documentation entirely.
- `DeleteFolder` and `DeleteFile` were missing both `<param>` and `<exception>` documentation — only a `<summary>` was present.
- `Upload` had empty `<param>` elements for `content` and `name`.
- No method on `IClient` documented its `cancellationToken` parameter.
- `List` documented `depth` only as ""Recursion depth"", with no indication of the meaningful values (notably `null` for infinite depth).

## Fix

Documentation-only changes to `WebDAVClient/IClient.cs`:

- Added the missing `<param name=""path"">` to `GetFolder`, `GetFile`, `DeleteFolder`, and `DeleteFile`, noting that the default `""/""` resolves to the configured base path.
- Filled in `Upload`'s empty `<param>` entries so it's clear that `content` is a readable stream positioned at the start of the data, and `name` is the target filename to create under `remoteFilePath`.
- Added a consistent `<param name=""cancellationToken"">Token used to cancel the asynchronous operation.</param>` to every async method on `IClient`.
- Expanded `List`'s `depth` documentation to spell out `0` (resource only), `1` (resource + immediate children), and `null` (`Depth: infinity`, frequently rejected by servers on collections).
- Added `<exception cref=""WebDAVException"">` to the data-bearing methods, and `<exception cref=""WebDAVConflictException"">` to `CreateDir` (which surfaces 409 conflicts when a parent path is missing — see `WebDAVException.GetHttpCode()` mapping).
- Noted on `Download` and `DownloadPartial` that the caller owns and must dispose the returned `Stream`, matching the existing release-notes / lifetime contract.

Verified with `dotnet build WebDAVClient/WebDAVClient.csproj -c Release` — 0 errors, no new `CS1591` / `CS1573` / `CS1574` warnings introduced.

## Tests

None — XML doc-comment-only change with no runtime behavior change. Per the PR-flow skill: ""Documentation changes do not need to be linted, built or tested unless there are specific tests for documentation.""

## Other changes

- No version bump and no `PackageReleaseNotes` entry — accumulates on `version-2.6` and is not worth a user-facing release-notes bullet.