### PR TITLE
Document Item model and remaining public types

### DIFF
--- a/WebDAVClient/Helpers/WebDAVConflictException.cs
+++ b/WebDAVClient/Helpers/WebDAVConflictException.cs
@@ -2,32 +2,73 @@ using System;
 
 namespace WebDAVClient.Helpers
 {
+    /// <summary>
+    /// Specialised <see cref="WebDAVException"/> raised when a WebDAV server
+    /// returns HTTP <c>409 Conflict</c>. Typically signals that a parent
+    /// resource is missing (for example creating a directory whose parent
+    /// does not exist) or that the operation conflicts with the current
+    /// state of the resource.
+    /// </summary>
     public class WebDAVConflictException : WebDAVException
     {
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with no message.
+        /// </summary>
         public WebDAVConflictException()
         {
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the specified error message.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
         public WebDAVConflictException(string message) 
             : base(message)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the specified error message and an implementation-defined error code.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="hr">An implementation-defined error code, exposed via <see cref="WebDAVException.ErrorCode"/>.</param>
         public WebDAVConflictException(string message, int hr) 
             : base(message, hr)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the specified error message and inner exception.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="innerException">The exception that caused this error, or <c>null</c>.</param>
         public WebDAVConflictException(string message, Exception innerException) 
             : base(message, innerException)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the HTTP status code returned by the server, an error message, and an inner exception.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server (typically 409), exposed via <see cref="WebDAVException.GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="innerException">The exception that caused this error, or <c>null</c>.</param>
         public WebDAVConflictException(int httpCode, string message, Exception innerException) 
             : base(httpCode, message, innerException)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the HTTP status code returned by the server and an error message.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server (typically 409), exposed via <see cref="WebDAVException.GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
         public WebDAVConflictException(int httpCode, string message) 
             : base(httpCode, message)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVConflictException"/> with the HTTP status code returned by the server, an error message, and an implementation-defined error code.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server (typically 409), exposed via <see cref="WebDAVException.GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="hr">An implementation-defined error code, exposed via <see cref="WebDAVException.ErrorCode"/>.</param>
         public WebDAVConflictException(int httpCode, string message, int hr) 
             : base(httpCode, message, hr)
         {}

--- a/WebDAVClient/Helpers/WebDAVException.cs
+++ b/WebDAVClient/Helpers/WebDAVException.cs
@@ -2,42 +2,95 @@ using System;
 
 namespace WebDAVClient.Helpers
 {
+    /// <summary>
+    /// Exception thrown by <see cref="IClient"/> operations when a WebDAV server
+    /// returns a non-success HTTP status (or when an underlying HTTP / parsing
+    /// error occurs). The HTTP status code is available via
+    /// <see cref="GetHttpCode"/>; 409 (Conflict) responses are surfaced as the
+    /// more specific <see cref="WebDAVConflictException"/>.
+    /// </summary>
     public class WebDAVException : Exception
     {
         private readonly int m_httpCode;
 
+        /// <summary>
+        /// Optional implementation-defined error code (HRESULT-style).
+        /// <c>0</c> when not set.
+        /// </summary>
         public int ErrorCode { get; }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with no message.
+        /// </summary>
         public WebDAVException()
         {
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the specified
+        /// error message.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
         public WebDAVException(string message)
             : base(message)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the specified
+        /// error message and an implementation-defined error code.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="hr">An implementation-defined error code, exposed via <see cref="ErrorCode"/>.</param>
         public WebDAVException(string message, int hr)
             : base(message)
         {
             ErrorCode = hr;
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the specified
+        /// error message and inner exception.
+        /// </summary>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="innerException">The exception that caused this error, or <c>null</c>.</param>
         public WebDAVException(string message, Exception innerException)
             : base(message, innerException)
         {}
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the HTTP status
+        /// code returned by the server, an error message, and an inner
+        /// exception.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server, exposed via <see cref="GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="innerException">The exception that caused this error, or <c>null</c>.</param>
         public WebDAVException(int httpCode, string message, Exception innerException)
             : base(message, innerException)
         {
             m_httpCode = httpCode;
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the HTTP status
+        /// code returned by the server and an error message.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server, exposed via <see cref="GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
         public WebDAVException(int httpCode, string message)
             : base(message)
         {
             m_httpCode = httpCode;
         }
 
+        /// <summary>
+        /// Initialises a new <see cref="WebDAVException"/> with the HTTP status
+        /// code returned by the server, an error message, and an
+        /// implementation-defined error code.
+        /// </summary>
+        /// <param name="httpCode">The HTTP status code returned by the server, exposed via <see cref="GetHttpCode"/>.</param>
+        /// <param name="message">A description of the error.</param>
+        /// <param name="hr">An implementation-defined error code, exposed via <see cref="ErrorCode"/>.</param>
         public WebDAVException(int httpCode, string message, int hr)
             : base(message)
         {
@@ -45,11 +98,20 @@ namespace WebDAVClient.Helpers
             ErrorCode = hr;
         }
 
+        /// <summary>
+        /// Returns the HTTP status code returned by the server, or <c>0</c>
+        /// when the exception was not constructed with one.
+        /// </summary>
         public int GetHttpCode()
         {
             return m_httpCode;
         }
 
+        /// <summary>
+        /// Returns a string that combines <see cref="GetHttpCode"/>,
+        /// <see cref="ErrorCode"/>, the message, and the base
+        /// <see cref="Exception.ToString"/> output.
+        /// </summary>
         public override string ToString()
         {
             var s = string.Format("HttpStatusCode: {0}", GetHttpCode());

--- a/WebDAVClient/HttpClient/HttpClientWrapper.cs
+++ b/WebDAVClient/HttpClient/HttpClientWrapper.cs
@@ -5,23 +5,37 @@ using System.Threading.Tasks;
 
 namespace WebDAVClient.HttpClient
 {
+    /// <summary>
+    /// Default <see cref="IHttpClientWrapper"/> implementation that delegates
+    /// to one or two <see cref="System.Net.Http.HttpClient"/> instances —
+    /// the primary client for regular requests and an optional second
+    /// client for uploads (so an upload-specific timeout can be applied
+    /// without affecting the primary client).
+    /// </summary>
     public class HttpClientWrapper : IHttpClientWrapper, IDisposable
     {
         private System.Net.Http.HttpClient m_httpClient;
         private System.Net.Http.HttpClient m_uploadHttpClient;
         private bool m_disposedValue;
 
+        /// <summary>
+        /// Initialises a new <see cref="HttpClientWrapper"/>.
+        /// </summary>
+        /// <param name="httpClient">The primary <see cref="System.Net.Http.HttpClient"/> used for non-upload requests.</param>
+        /// <param name="uploadHttpClient">Optional secondary <see cref="System.Net.Http.HttpClient"/> used for upload requests. When <c>null</c>, <paramref name="httpClient"/> is used for uploads as well.</param>
         public HttpClientWrapper(System.Net.Http.HttpClient httpClient, System.Net.Http.HttpClient uploadHttpClient = null)
         {
             m_httpClient = httpClient;
             m_uploadHttpClient = uploadHttpClient ?? httpClient;
         }
 
+        /// <inheritdoc />
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption responseHeadersRead, CancellationToken cancellationToken = default)
         {
             return m_httpClient.SendAsync(request, responseHeadersRead, cancellationToken);
         }
 
+        /// <inheritdoc />
         public Task<HttpResponseMessage> SendUploadAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
         {
             return m_uploadHttpClient.SendAsync(request, cancellationToken);
@@ -29,6 +43,13 @@ namespace WebDAVClient.HttpClient
 
 
         #region IDisposable methods
+        /// <summary>
+        /// Releases the unmanaged resources used by the
+        /// <see cref="HttpClientWrapper"/> and, when <paramref name="disposing"/>
+        /// is <c>true</c>, the managed <see cref="System.Net.Http.HttpClient"/>
+        /// instances it owns.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> when called from <see cref="Dispose()"/>; <c>false</c> when called from a finaliser.</param>
         protected virtual void Dispose(bool disposing)
         {
             if (!m_disposedValue)
@@ -48,6 +69,10 @@ namespace WebDAVClient.HttpClient
             }
         }
 
+        /// <summary>
+        /// Disposes the wrapper and the underlying
+        /// <see cref="System.Net.Http.HttpClient"/> instance(s) it owns.
+        /// </summary>
         public void Dispose()
         {
             // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method

--- a/WebDAVClient/HttpClient/IHttpClientWrapper.cs
+++ b/WebDAVClient/HttpClient/IHttpClientWrapper.cs
@@ -4,9 +4,34 @@ using System.Threading.Tasks;
 
 namespace WebDAVClient.HttpClient
 {
+    /// <summary>
+    /// Abstraction over <see cref="System.Net.Http.HttpClient"/> used by
+    /// <see cref="Client"/> so that a single underlying <c>HttpClient</c>
+    /// instance can be reused (avoiding the well-known socket-exhaustion
+    /// leak) and so that the client is testable without real network I/O.
+    /// Implement this interface to inject a custom HTTP transport.
+    /// </summary>
     public interface IHttpClientWrapper
     {
+        /// <summary>
+        /// Sends a non-upload request (PROPFIND, GET, MKCOL, MOVE, COPY,
+        /// DELETE, ...) using the primary <c>HttpClient</c>.
+        /// </summary>
+        /// <param name="request">The HTTP request to send. The wrapper does not dispose the request — the caller retains ownership.</param>
+        /// <param name="responseHeadersRead">When the operation should complete (typically <see cref="HttpCompletionOption.ResponseHeadersRead"/> so that response bodies / streams are read on demand).</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The HTTP response. The caller is responsible for disposing it (except when its content stream is handed back to the user, as in <see cref="IClient.Download"/>).</returns>
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption responseHeadersRead, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Sends an upload (PUT) request using the upload <c>HttpClient</c>,
+        /// which may have a different timeout from the primary client. When
+        /// no separate upload client was supplied at construction time, this
+        /// falls through to the primary client.
+        /// </summary>
+        /// <param name="request">The upload HTTP request to send. The wrapper does not dispose the request — the caller retains ownership.</param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>The HTTP response. The caller is responsible for disposing it.</returns>
         Task<HttpResponseMessage> SendUploadAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
     }
 }

--- a/WebDAVClient/Model/Item.cs
+++ b/WebDAVClient/Model/Item.cs
@@ -2,16 +2,86 @@
 
 namespace WebDAVClient.Model
 {
+    /// <summary>
+    /// Represents a single WebDAV resource (file or collection) returned by a
+    /// <c>PROPFIND</c> response. Instances are produced by
+    /// <see cref="WebDAVClient.Helpers.ResponseParser"/> and returned from
+    /// <see cref="IClient.List"/>, <see cref="IClient.GetFolder"/>, and
+    /// <see cref="IClient.GetFile"/>.
+    /// </summary>
     public class Item
     {
+        /// <summary>
+        /// The <c>&lt;D:href&gt;</c> value reported by the server for this resource.
+        /// Per RFC 4918 this may be either an absolute URL (for example
+        /// <c>https://server/path/file.txt</c>) or an absolute path on the server
+        /// (for example <c>/path/file.txt</c>) — the form is server-controlled and
+        /// is preserved as received, with one normalisation: trailing <c>/</c>
+        /// characters are stripped for non-collection items so that file hrefs
+        /// never end with a slash. Collection (folder) hrefs always end with a
+        /// trailing <c>/</c>; this distinction is load-bearing — see
+        /// <see cref="IsCollection"/>.
+        /// </summary>
         public string Href { get; set; }
+
+        /// <summary>
+        /// The <c>&lt;D:creationdate&gt;</c> value reported by the server, parsed
+        /// as a <see cref="DateTime"/>. <c>null</c> when the server did not
+        /// return the property or when the value could not be parsed.
+        /// </summary>
         public DateTime? CreationDate { get; set; }
+
+        /// <summary>
+        /// The opaque entity tag (<c>&lt;D:getetag&gt;</c>) reported by the
+        /// server. Useful for conditional requests and change detection.
+        /// <c>null</c> when the server did not return the property.
+        /// </summary>
         public string Etag { get; set; }
+
+        /// <summary>
+        /// <c>true</c> when the server marks this resource as hidden (via the
+        /// non-standard but widely used <c>&lt;D:ishidden&gt;</c> property).
+        /// </summary>
         public bool IsHidden { get; set; }
+
+        /// <summary>
+        /// <c>true</c> when this item is a collection (folder), <c>false</c>
+        /// when it is a file. Determined from the resource type
+        /// (<c>&lt;D:resourcetype&gt;&lt;D:collection/&gt;</c>) or, as a
+        /// fallback, the <c>&lt;D:iscollection&gt;</c> property. Collection
+        /// items also have a trailing <c>/</c> on <see cref="Href"/>.
+        /// </summary>
         public bool IsCollection { get; set; }
+
+        /// <summary>
+        /// The MIME type reported by the server in <c>&lt;D:getcontenttype&gt;</c>
+        /// (for example <c>text/plain</c>). Typically <c>null</c> for
+        /// collections.
+        /// </summary>
         public string ContentType { get; set; }
+
+        /// <summary>
+        /// The <c>&lt;D:getlastmodified&gt;</c> value reported by the server,
+        /// parsed as a <see cref="DateTime"/>. <c>null</c> when the server did
+        /// not return the property or when the value could not be parsed.
+        /// </summary>
         public DateTime? LastModified { get; set; }
+
+        /// <summary>
+        /// The human-readable name reported by the server in
+        /// <c>&lt;D:displayname&gt;</c>. When the server omits this property
+        /// the parser falls back to the URL-decoded final segment of
+        /// <see cref="Href"/>, so <see cref="DisplayName"/> is normally a
+        /// usable name even when the server is sparse.
+        /// </summary>
         public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The size of the resource in bytes, as reported by the server in
+        /// <c>&lt;D:getcontentlength&gt;</c>. <c>null</c> when the server did
+        /// not return the property or when the value could not be parsed —
+        /// notably, collections typically do not report a content length.
+        /// </summary>
         public long? ContentLength { get; set; }
     }
 }


### PR DESCRIPTION
## Issue

Several public types in the ``WebDAVClient`` project had no XML doc comments at all — most notably the ``Item`` model (the primary return type from ``IClient.List`` / ``GetFolder`` / ``GetFile``), the two exception types thrown from every public operation, and the ``IHttpClientWrapper`` extension point.

## Fix

Documentation-only additions:

- **``WebDAVClient/Model/Item.cs``** — class-level ``<summary>`` linking to ``ResponseParser`` and the ``IClient`` methods that produce instances, plus per-property ``<summary>`` on all nine properties. Captures the load-bearing contracts: ``Href`` may be absolute URL or absolute path (server-controlled), trailing ``/`` is stripped for files but kept for collections, ``IsCollection`` is sourced from ``<D:resourcetype><D:collection/>`` with ``<D:iscollection>`` as a fallback, ``DisplayName`` falls back to the URL-decoded final segment of ``Href`` when the server omits it, and the nullable date/length properties are ``null`` when the server did not return the property or parsing failed.

- **``WebDAVClient/Helpers/WebDAVException.cs``** — type-level ``<summary>`` describing when it is thrown and its relationship to ``WebDAVConflictException``, plus per-member docs on every constructor overload, the ``ErrorCode`` property, ``GetHttpCode()``, and the ``ToString()`` override.

- **``WebDAVClient/Helpers/WebDAVConflictException.cs``** — type-level ``<summary>`` clarifying that it is the 409-specific subclass (typically signals a missing parent), plus per-constructor summaries that cross-reference the base-class properties.

- **``WebDAVClient/HttpClient/IHttpClientWrapper.cs``** — type-level ``<summary>`` explaining the wrapper's role (single-instance ``HttpClient`` reuse to avoid socket exhaustion, testability), plus parameter / return docs on ``SendAsync`` and ``SendUploadAsync`` including the request/response disposal contracts (notably the ``Download`` exception where the response stream is handed back to the caller).

- **``WebDAVClient/HttpClient/HttpClientWrapper.cs``** — type-level ``<summary>`` describing the optional second upload client, constructor parameter docs, ``<inheritdoc />`` on the interface methods, and an explicit summary on ``Dispose`` / ``Dispose(bool)``.

Out of scope:

- ``Helpers/ResponseParser`` — internal type, not part of the public surface.
- ``Client.cs`` — large existing API and not part of this user request; left for a follow-up.

Verified with ``dotnet build WebDAVClient/WebDAVClient.csproj -c Release`` — 0 errors, no new doc warnings.

## Tests

None — XML doc-comment-only changes with no runtime behavior change. Per the PR-flow skill: "Documentation changes do not need to be linted, built or tested unless there are specific tests for documentation."

## Other changes

- No version bump and no ``PackageReleaseNotes`` entry — accumulates on ``version-2.6`` and is not worth a user-facing release-notes bullet.