### PR TITLE
Add WebDAV LOCK / UNLOCK support per RFC 4918 sections 9.10-9.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ WebDAVClient is available as a [NuGet package](https://www.nuget.org/packages/We
 ## Release Notes
 
 + **2.6.0** _(upcoming)_  Security & hardening:
-  - **XXE hardening**: `ResponseParser` now sets `DtdProcessing = Prohibit` and `XmlResolver = null` explicitly so XXE attacks from malicious WebDAV servers are blocked even on runtimes (e.g. Mono) where the .NET defaults differ.
+  - **WebDAV LOCK / UNLOCK** (RFC 4918 §9.10–9.11): new `LockFile`/`LockFolder`/`UnlockFile`/`UnlockFolder`/`RefreshLock` methods on `IClient`. Returns a strongly-typed `LockInfo` (token, owner, type/scope, depth, timeout, lock-root). Lock tokens are normalized so callers can pass them either bare or `<...>`-wrapped.
+  - **XXE hardening**:`ResponseParser` now sets `DtdProcessing = Prohibit` and `XmlResolver = null` explicitly so XXE attacks from malicious WebDAV servers are blocked even on runtimes (e.g. Mono) where the .NET defaults differ.
   - **Certificate validation wired**: `ServerCertificateValidationCallback` is now actually plumbed into the underlying `HttpClientHandler` (it was a dead property before). When unset, the wired closure defers to the platform's default trust decision.
   - **SSRF protection**: `BuildServerUrl` now validates that any absolute URI it accepts (path argument or server-resolved base path) belongs to the configured `Server` host, preventing a malicious server from steering the client at a foreign host via crafted `<href>` values.
   - **Header injection protection**: `CustomHeaders` entries are now validated for CR/LF in both the name and the value before being sent.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ WebDAVClient is available as a [NuGet package](https://www.nuget.org/packages/We
 
 ## Release Notes
 
-+ **2.6.0** _(upcoming)_  Security & hardening:
++ **2.7.0** _(upcoming)_  Security & hardening:
   - **WebDAV LOCK / UNLOCK** (RFC 4918 §9.10–9.11): new `LockFile`/`LockFolder`/`UnlockFile`/`UnlockFolder`/`RefreshLock` methods on `IClient`. Returns a strongly-typed `LockInfo` (token, owner, type/scope, depth, timeout, lock-root). Lock tokens are normalized so callers can pass them either bare or `<...>`-wrapped.
   - **XXE hardening**:`ResponseParser` now sets `DtdProcessing = Prohibit` and `XmlResolver = null` explicitly so XXE attacks from malicious WebDAV servers are blocked even on runtimes (e.g. Mono) where the .NET defaults differ.
   - **Certificate validation wired**: `ServerCertificateValidationCallback` is now actually plumbed into the underlying `HttpClientHandler` (it was a dead property before). When unset, the wired closure defers to the platform's default trust decision.

--- a/WebDAVClient.UnitTests/ClientLockTests.cs
+++ b/WebDAVClient.UnitTests/ClientLockTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebDAVClient.Helpers;
+using WebDAVClient.HttpClient;
+using WebDAVClient.UnitTests.Helpers;
+
+namespace WebDAVClient.UnitTests.ClientTests
+{
+    /// <summary>
+    /// Behavioural tests for the LOCK / UNLOCK / refresh-lock surface added per RFC 4918
+    /// §9.10–9.11. They exercise both the request shape (method, URL, headers, body) and the
+    /// response parsing (LockInfo population, error mapping).
+    /// </summary>
+    [TestClass]
+    public class ClientLockTests
+    {
+        private const string Server = "http://example.com";
+        private const string BasePath = "/webdav/";
+
+        // Mirrors the convention used by ClientTests: the very first request from a freshly-
+        // constructed Client is the base-path PROPFIND that resolves m_encodedBasePath. We
+        // intercept it here so individual tests only see the LOCK/UNLOCK call.
+        private static Func<HttpRequestMessage, HttpResponseMessage> Responder(Func<HttpRequestMessage, HttpResponseMessage> handler)
+        {
+            int seen = 0;
+            return request =>
+            {
+                if (Interlocked.Increment(ref seen) == 1)
+                {
+                    return StubHttpMessageHandler.Multistatus(WebDAVResponses.Root(BasePath));
+                }
+                return handler(request);
+            };
+        }
+
+        private static HttpResponseMessage LockOk(string body, string lockTokenHeader)
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, Encoding.UTF8, "application/xml")
+            };
+            if (lockTokenHeader != null)
+            {
+                response.Headers.Add("Lock-Token", lockTokenHeader);
+            }
+            return response;
+        }
+
+        // -------------------- LockFile --------------------
+
+        [TestMethod]
+        public async Task LockFile_sends_LOCK_with_depth_0_timeout_and_lockinfo_body()
+        {
+            using var harness = new ClientHarness(Responder(req =>
+                LockOk(WebDAVResponses.LockResponse(), "<opaquelocktoken:abc-123>")), Server, BasePath);
+
+            var info = await harness.Client.LockFile("file.txt", timeoutSeconds: 300);
+
+            var lockRequest = harness.Handler.Requests.Last();
+            Assert.AreEqual("LOCK", lockRequest.Method.Method);
+            Assert.AreEqual("/webdav/file.txt", lockRequest.RequestUri.AbsolutePath);
+            Assert.AreEqual("0", lockRequest.Headers["Depth"][0]);
+            Assert.AreEqual("Second-300", lockRequest.Headers["Timeout"][0]);
+
+            var body = lockRequest.BodyAsString();
+            StringAssert.Contains(body, "<D:lockinfo");
+            StringAssert.Contains(body, "<D:exclusive/>");
+            StringAssert.Contains(body, "<D:write/>");
+            StringAssert.Contains(body, "<D:owner>WebDAVClient</D:owner>");
+
+            // Token comes from the Lock-Token header (canonical per RFC 4918 §10.5),
+            // bare form (no angle brackets).
+            Assert.AreEqual("opaquelocktoken:abc-123", info.Token);
+        }
+
+        [TestMethod]
+        public async Task LockFile_populates_LockInfo_from_response_body()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                LockOk(WebDAVResponses.LockResponse(
+                    token: "opaquelocktoken:in-body-token",
+                    lockRoot: "/webdav/file.txt",
+                    depth: "0",
+                    scope: "exclusive",
+                    timeout: "Second-3600",
+                    ownerInnerXml: "<D:href>http://example.org/me</D:href>"),
+                lockTokenHeader: null)), Server, BasePath);
+
+            var info = await harness.Client.LockFile("file.txt");
+
+            // No Lock-Token header → falls back to body parsing.
+            Assert.AreEqual("opaquelocktoken:in-body-token", info.Token);
+            Assert.AreEqual("write", info.LockType);
+            Assert.AreEqual("exclusive", info.LockScope);
+            Assert.AreEqual("0", info.Depth);
+            Assert.AreEqual(3600, info.TimeoutSeconds);
+            Assert.AreEqual("/webdav/file.txt", info.LockRoot);
+            StringAssert.Contains(info.Owner, "http://example.org/me");
+        }
+
+        [TestMethod]
+        public async Task LockFile_uses_custom_owner_in_request_body()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                LockOk(WebDAVResponses.LockResponse(), "<opaquelocktoken:t>")), Server, BasePath);
+
+            // Special characters must be XML-escaped — no raw <, > or & allowed in the body.
+            await harness.Client.LockFile("file.txt", owner: "alice <a&b>");
+
+            var body = harness.Handler.Requests.Last().BodyAsString();
+            StringAssert.Contains(body, "<D:owner>alice &lt;a&amp;b&gt;</D:owner>");
+        }
+
+        [TestMethod]
+        public async Task LockFile_rejects_non_positive_timeout()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                LockOk(WebDAVResponses.LockResponse(), "<opaquelocktoken:t>")), Server, BasePath);
+
+            await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(
+                () => harness.Client.LockFile("file.txt", timeoutSeconds: 0));
+        }
+
+        [TestMethod]
+        public async Task LockFile_throws_WebDAVException_on_423_Locked()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly((HttpStatusCode)423, "<error/>")), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(
+                () => harness.Client.LockFile("file.txt"));
+            Assert.AreEqual(423, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task LockFolder_sends_LOCK_with_depth_infinity_and_trailing_slash()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                LockOk(WebDAVResponses.LockResponse(depth: "infinity"), "<opaquelocktoken:f>")), Server, BasePath);
+
+            await harness.Client.LockFolder("folder");
+
+            var lockRequest = harness.Handler.Requests.Last();
+            Assert.AreEqual("LOCK", lockRequest.Method.Method);
+            Assert.IsTrue(lockRequest.RequestUri.AbsolutePath.EndsWith("/"),
+                "Folder lock URL should have a trailing slash, was: " + lockRequest.RequestUri.AbsolutePath);
+            Assert.AreEqual("infinity", lockRequest.Headers["Depth"][0]);
+        }
+
+        [TestMethod]
+        public async Task LockFolder_treats_207_MultiStatus_as_failure()
+        {
+            // RFC 4918 §9.10.6: 207 from LOCK indicates partial failure. Must NOT be reported as
+            // a granted lock — that would let callers issue writes on a resource the server
+            // didn't actually lock for them.
+            using var harness = new ClientHarness(Responder(_ => new HttpResponseMessage((HttpStatusCode)207)
+            {
+                Content = new StringContent("<multistatus xmlns=\"DAV:\"/>", Encoding.UTF8, "application/xml")
+            }), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(
+                () => harness.Client.LockFolder("folder"));
+            Assert.AreEqual(207, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task LockFile_throws_when_response_lacks_token_in_both_header_and_body()
+        {
+            // Server responds 200 OK but with neither a Lock-Token header nor a parseable body.
+            // We must not return a LockInfo with a null Token — callers couldn't unlock it.
+            using var harness = new ClientHarness(Responder(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("<prop xmlns=\"DAV:\"></prop>", Encoding.UTF8, "application/xml")
+            }), Server, BasePath);
+
+            await Assert.ThrowsExceptionAsync<WebDAVException>(
+                () => harness.Client.LockFile("file.txt"));
+        }
+
+        // -------------------- UnlockFile / UnlockFolder --------------------
+
+        [TestMethod]
+        public async Task UnlockFile_sends_UNLOCK_with_bracketed_LockToken_header()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.NoContent)), Server, BasePath);
+
+            await harness.Client.UnlockFile("file.txt", "opaquelocktoken:abc-123");
+
+            var unlockRequest = harness.Handler.Requests.Last();
+            Assert.AreEqual("UNLOCK", unlockRequest.Method.Method);
+            Assert.AreEqual("<opaquelocktoken:abc-123>", unlockRequest.Headers["Lock-Token"][0]);
+            Assert.IsNull(unlockRequest.Body, "UNLOCK must not send a body");
+        }
+
+        [TestMethod]
+        public async Task UnlockFile_accepts_bracketed_caller_token_and_normalizes_it()
+        {
+            // Real users copy the Lock-Token value out of response headers including the angle
+            // brackets. The client must accept that form and not emit "<<token>>".
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.NoContent)), Server, BasePath);
+
+            await harness.Client.UnlockFile("file.txt", "<opaquelocktoken:abc-123>");
+
+            var unlockRequest = harness.Handler.Requests.Last();
+            Assert.AreEqual("<opaquelocktoken:abc-123>", unlockRequest.Headers["Lock-Token"][0]);
+        }
+
+        [TestMethod]
+        public async Task UnlockFile_rejects_null_or_malformed_token()
+        {
+            using var harness = new ClientHarness(_ =>
+                StubHttpMessageHandler.Multistatus(WebDAVResponses.Root(BasePath)), Server, BasePath);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => harness.Client.UnlockFile("file.txt", lockToken: null));
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => harness.Client.UnlockFile("file.txt", lockToken: ""));
+            // CR/LF in the token would otherwise allow header injection in Lock-Token.
+            await Assert.ThrowsExceptionAsync<ArgumentException>(
+                () => harness.Client.UnlockFile("file.txt", lockToken: "tok\r\nX-Injected: yes"));
+        }
+
+        [TestMethod]
+        public async Task UnlockFile_throws_WebDAVException_on_non_204()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.Conflict)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(
+                () => harness.Client.UnlockFile("file.txt", "opaquelocktoken:t"));
+            Assert.AreEqual(409, ex.GetHttpCode());
+        }
+
+        [TestMethod]
+        public async Task UnlockFolder_sends_UNLOCK_to_trailing_slash_url()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.NoContent)), Server, BasePath);
+
+            await harness.Client.UnlockFolder("folder", "opaquelocktoken:t");
+
+            var req = harness.Handler.Requests.Last();
+            Assert.IsTrue(req.RequestUri.AbsolutePath.EndsWith("/"));
+        }
+
+        // -------------------- RefreshLock --------------------
+
+        [TestMethod]
+        public async Task RefreshLock_sends_LOCK_with_If_header_no_body_and_new_timeout()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                LockOk(WebDAVResponses.LockResponse(token: "opaquelocktoken:t", timeout: "Second-1200"),
+                       "<opaquelocktoken:t>")), Server, BasePath);
+
+            var info = await harness.Client.RefreshLock("file.txt", "opaquelocktoken:t", timeoutSeconds: 1200);
+
+            var req = harness.Handler.Requests.Last();
+            Assert.AreEqual("LOCK", req.Method.Method);
+            Assert.IsNull(req.Body, "Refresh LOCK must have no request body");
+            Assert.AreEqual("(<opaquelocktoken:t>)", req.Headers["If"][0]);
+            Assert.AreEqual("Second-1200", req.Headers["Timeout"][0]);
+            Assert.AreEqual(1200, info.TimeoutSeconds);
+            Assert.AreEqual("opaquelocktoken:t", info.Token);
+        }
+
+        [TestMethod]
+        public async Task RefreshLock_falls_back_to_caller_token_when_response_body_is_empty()
+        {
+            // Some servers return 200 OK without an activelock body on refresh. The returned
+            // LockInfo must still carry the original token so callers can keep refreshing.
+            using var harness = new ClientHarness(Responder(_ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("", Encoding.UTF8, "application/xml")
+            }), Server, BasePath);
+
+            var info = await harness.Client.RefreshLock("file.txt", "opaquelocktoken:keepme");
+            Assert.AreEqual("opaquelocktoken:keepme", info.Token);
+        }
+
+        [TestMethod]
+        public async Task RefreshLock_throws_on_412_PreconditionFailed()
+        {
+            using var harness = new ClientHarness(Responder(_ =>
+                StubHttpMessageHandler.StatusOnly(HttpStatusCode.PreconditionFailed)), Server, BasePath);
+
+            var ex = await Assert.ThrowsExceptionAsync<WebDAVException>(
+                () => harness.Client.RefreshLock("file.txt", "opaquelocktoken:stale"));
+            Assert.AreEqual(412, ex.GetHttpCode());
+        }
+
+        // -------------------- LockResponseParser direct tests --------------------
+
+        [TestMethod]
+        public void LockResponseParser_returns_null_when_no_activelock_present()
+        {
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes("<prop xmlns=\"DAV:\"></prop>"));
+            Assert.IsNull(LockResponseParser.Parse(stream));
+        }
+
+        [TestMethod]
+        public void LockResponseParser_handles_Infinite_timeout()
+        {
+            Assert.IsNull(LockResponseParser.ParseTimeout("Infinite"));
+            Assert.AreEqual(120, LockResponseParser.ParseTimeout("Second-120"));
+            Assert.AreEqual(60, LockResponseParser.ParseTimeout("Second-60, Infinite"));
+            Assert.IsNull(LockResponseParser.ParseTimeout("garbage"));
+            Assert.IsNull(LockResponseParser.ParseTimeout(""));
+            Assert.IsNull(LockResponseParser.ParseTimeout(null));
+        }
+    }
+}

--- a/WebDAVClient.UnitTests/Helpers/WebDAVResponses.cs
+++ b/WebDAVClient.UnitTests/Helpers/WebDAVResponses.cs
@@ -94,5 +94,29 @@ namespace WebDAVClient.UnitTests.Helpers
         </D:propstat>
     </D:response>
 </D:multistatus>";
+
+        // RFC 4918 §9.10.7-style LOCK response body. Includes a single <D:activelock> with all
+        // typical fields populated so the parser tests can assert against every one of them.
+        public static string LockResponse(
+            string token = "opaquelocktoken:e71d4fae-5dec-22d6-fea5-00a0c91e6be4",
+            string lockRoot = "/webdav/file.txt",
+            string depth = "0",
+            string scope = "exclusive",
+            string ownerInnerXml = "<D:href>http://example.org/~ejw/contact.html</D:href>",
+            string timeout = "Second-604800") =>
+            $@"<?xml version=""1.0"" encoding=""utf-8""?>
+<D:prop xmlns:D=""DAV:"">
+    <D:lockdiscovery>
+        <D:activelock>
+            <D:locktype><D:write/></D:locktype>
+            <D:lockscope><D:{scope}/></D:lockscope>
+            <D:depth>{depth}</D:depth>
+            <D:owner>{ownerInnerXml}</D:owner>
+            <D:timeout>{timeout}</D:timeout>
+            <D:locktoken><D:href>{token}</D:href></D:locktoken>
+            <D:lockroot><D:href>{lockRoot}</D:href></D:lockroot>
+        </D:activelock>
+    </D:lockdiscovery>
+</D:prop>";
     }
 }

--- a/WebDAVClient/Client.cs
+++ b/WebDAVClient/Client.cs
@@ -19,6 +19,8 @@ namespace WebDAVClient
         private static readonly HttpMethod m_propFindMethod = new HttpMethod("PROPFIND");
         private static readonly HttpMethod m_moveMethod = new HttpMethod("MOVE");
         private static readonly HttpMethod m_copyMethod = new HttpMethod("COPY");
+        private static readonly HttpMethod s_lockMethod = new HttpMethod("LOCK");
+        private static readonly HttpMethod s_unlockMethod = new HttpMethod("UNLOCK");
 
         private static readonly HttpMethod m_mkColMethod = new HttpMethod(WebRequestMethods.Http.MkCol);
 
@@ -46,6 +48,18 @@ namespace WebDAVClient
         private static readonly byte[] s_propFindRequestContentBytes = Encoding.UTF8.GetBytes(c_propFindRequestContent);
         private static readonly byte[] s_moveRequestContentBytes = Encoding.UTF8.GetBytes("MOVE");
         private static readonly byte[] s_copyRequestContentBytes = Encoding.UTF8.GetBytes("COPY");
+
+        // RFC 4918 §9.10 LOCK request body. The owner is interpolated as raw text content
+        // of <D:owner> — callers' owner strings are XML-escaped before substitution.
+        private const string c_lockRequestContentFormat =
+            "<?xml version=\"1.0\" encoding=\"utf-8\" ?>" +
+            "<D:lockinfo xmlns:D=\"DAV:\">" +
+            "<D:lockscope><D:exclusive/></D:lockscope>" +
+            "<D:locktype><D:write/></D:locktype>" +
+            "<D:owner>{0}</D:owner>" +
+            "</D:lockinfo>";
+
+        private const string c_defaultLockOwner = "WebDAVClient";
 
         private IHttpClientWrapper m_httpClientWrapper;
         private readonly bool m_shouldDispose;
@@ -499,6 +513,103 @@ namespace WebDAVClient
             return await Copy(srcUri.Uri, dstUri.Uri, cancellationToken).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Acquire an exclusive write lock on a file (RFC 4918 §9.10, <c>Depth: 0</c>).
+        /// </summary>
+        public async Task<LockInfo> LockFile(string filePath, int timeoutSeconds = 600, string owner = null, CancellationToken cancellationToken = default)
+        {
+            var uri = await GetServerUrl(filePath, false).ConfigureAwait(false);
+            return await Lock(uri.Uri, depth: "0", timeoutSeconds, owner, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquire an exclusive write lock on a folder (RFC 4918 §9.10, <c>Depth: infinity</c>).
+        /// </summary>
+        public async Task<LockInfo> LockFolder(string folderPath, int timeoutSeconds = 600, string owner = null, CancellationToken cancellationToken = default)
+        {
+            var uri = await GetServerUrl(folderPath, true).ConfigureAwait(false);
+            return await Lock(uri.Uri, depth: "infinity", timeoutSeconds, owner, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Release a lock previously acquired with <see cref="LockFile"/> (RFC 4918 §9.11).
+        /// </summary>
+        public async Task UnlockFile(string filePath, string lockToken, CancellationToken cancellationToken = default)
+        {
+            var uri = await GetServerUrl(filePath, false).ConfigureAwait(false);
+            await Unlock(uri.Uri, lockToken, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Release a lock previously acquired with <see cref="LockFolder"/> (RFC 4918 §9.11).
+        /// </summary>
+        public async Task UnlockFolder(string folderPath, string lockToken, CancellationToken cancellationToken = default)
+        {
+            var uri = await GetServerUrl(folderPath, true).ConfigureAwait(false);
+            await Unlock(uri.Uri, lockToken, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Refresh an existing lock (RFC 4918 §9.10.2). Sends a body-less LOCK request with the
+        /// <c>If</c> header carrying the current lock token and a new <c>Timeout</c> header.
+        /// </summary>
+        public async Task<LockInfo> RefreshLock(string path, string lockToken, int timeoutSeconds = 600, CancellationToken cancellationToken = default)
+        {
+            if (timeoutSeconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Lock timeout must be greater than zero seconds.");
+
+            var bareToken = NormalizeLockToken(lockToken);
+
+            // Folder vs file is unknown at this entry point — but the URL shape only differs by a
+            // trailing slash, and we want to refresh the same href the caller originally locked.
+            // GetServerUrl with appendTrailingSlash=false leaves the caller's path as-is (it only
+            // adds a slash when asked to), which matches how the original Lock URL was built.
+            var uri = await GetServerUrl(path, false).ConfigureAwait(false);
+
+            IDictionary<string, string> headers = new Dictionary<string, string>(2)
+            {
+                { "If", "(<" + bareToken + ">)" },
+                { "Timeout", "Second-" + timeoutSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) }
+            };
+
+            HttpResponseMessage response = null;
+            try
+            {
+                response = await HttpRequest(uri.Uri, s_lockMethod, headers, content: null, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    throw new WebDAVException((int)response.StatusCode, "Failed refreshing lock.");
+                }
+
+                LockInfo info = null;
+                if (response.Content != null)
+                {
+                    using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        info = LockResponseParser.Parse(stream);
+                    }
+                }
+
+                if (info == null)
+                {
+                    // Some servers omit the body on refresh. Carry the caller's token through so the
+                    // returned LockInfo is still actionable for the next refresh / unlock.
+                    info = new LockInfo { Token = bareToken };
+                }
+                else if (string.IsNullOrEmpty(info.Token))
+                {
+                    info.Token = bareToken;
+                }
+
+                return info;
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+        }
+
         #endregion
         
         #region Private methods
@@ -585,6 +696,148 @@ namespace WebDAVClient
             }
 
             return response.IsSuccessStatusCode;
+        }
+
+        private async Task<LockInfo> Lock(Uri uri, string depth, int timeoutSeconds, string owner, CancellationToken cancellationToken)
+        {
+            if (timeoutSeconds <= 0)
+                throw new ArgumentOutOfRangeException(nameof(timeoutSeconds), "Lock timeout must be greater than zero seconds.");
+
+            var ownerText = string.IsNullOrEmpty(owner) ? c_defaultLockOwner : owner;
+            var body = Encoding.UTF8.GetBytes(string.Format(c_lockRequestContentFormat, EscapeXml(ownerText)));
+
+            IDictionary<string, string> headers = new Dictionary<string, string>(2)
+            {
+                { "Depth", depth },
+                { "Timeout", "Second-" + timeoutSeconds.ToString(System.Globalization.CultureInfo.InvariantCulture) }
+            };
+
+            HttpResponseMessage response = null;
+            try
+            {
+                response = await HttpRequest(uri, s_lockMethod, headers, body, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                // RFC 4918 §9.10.6: 207 Multi-Status from a depth-infinity LOCK indicates that
+                // at least one member could not be locked — the lock as requested was NOT granted
+                // and must not be treated as success.
+                if (response.StatusCode != HttpStatusCode.OK &&
+                    response.StatusCode != HttpStatusCode.Created)
+                {
+                    throw new WebDAVException((int)response.StatusCode, "Failed acquiring lock.");
+                }
+
+                LockInfo info = null;
+                if (response.Content != null)
+                {
+                    using (var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        info = LockResponseParser.Parse(stream);
+                    }
+                }
+
+                if (info == null)
+                {
+                    info = new LockInfo();
+                }
+
+                // RFC 4918 §10.5: the canonical lock token of the new lock is the value of the
+                // Lock-Token response header. Prefer the header value over any body-derived token
+                // (and use the header to populate Token when the body parser came up empty).
+                var headerToken = ExtractLockTokenHeader(response);
+                if (!string.IsNullOrEmpty(headerToken))
+                {
+                    info.Token = headerToken;
+                }
+
+                if (string.IsNullOrEmpty(info.Token))
+                {
+                    throw new WebDAVException((int)response.StatusCode,
+                        "Lock response did not contain a lock token in either the Lock-Token header or the response body.");
+                }
+
+                return info;
+            }
+            finally
+            {
+                response?.Dispose();
+            }
+        }
+
+        private async Task Unlock(Uri uri, string lockToken, CancellationToken cancellationToken)
+        {
+            var bareToken = NormalizeLockToken(lockToken);
+
+            IDictionary<string, string> headers = new Dictionary<string, string>(1)
+            {
+                { "Lock-Token", "<" + bareToken + ">" }
+            };
+
+            using (var response = await HttpRequest(uri, s_unlockMethod, headers, content: null, cancellationToken: cancellationToken).ConfigureAwait(false))
+            {
+                if (response.StatusCode != HttpStatusCode.NoContent)
+                {
+                    throw new WebDAVException((int)response.StatusCode, "Failed releasing lock.");
+                }
+            }
+        }
+
+        // Lock tokens flow through this client in *bare* form (no surrounding angle brackets).
+        // The Lock-Token and If headers add the brackets when emitting. Accept either form from
+        // callers because real-world tokens are commonly copy-pasted from response headers
+        // including the brackets.
+        internal static string NormalizeLockToken(string lockToken)
+        {
+            if (string.IsNullOrWhiteSpace(lockToken))
+                throw new ArgumentException("Lock token must be a non-empty string.", nameof(lockToken));
+
+            var trimmed = lockToken.Trim();
+            if (trimmed.Length >= 2 && trimmed[0] == '<' && trimmed[trimmed.Length - 1] == '>')
+            {
+                trimmed = trimmed.Substring(1, trimmed.Length - 2).Trim();
+            }
+
+            if (trimmed.Length == 0
+                || trimmed.IndexOf('<') >= 0
+                || trimmed.IndexOf('>') >= 0
+                || trimmed.IndexOf('\r') >= 0
+                || trimmed.IndexOf('\n') >= 0)
+            {
+                throw new ArgumentException("Lock token is malformed.", nameof(lockToken));
+            }
+
+            return trimmed;
+        }
+
+        // RFC 4918 §10.5: Lock-Token = "Lock-Token" ":" Coded-URL where Coded-URL = "<" absolute-URI ">"
+        private static string ExtractLockTokenHeader(HttpResponseMessage response)
+        {
+            if (response.Headers.TryGetValues("Lock-Token", out var values))
+            {
+                foreach (var v in values)
+                {
+                    if (string.IsNullOrWhiteSpace(v))
+                        continue;
+                    var trimmed = v.Trim();
+                    if (trimmed.Length >= 2 && trimmed[0] == '<' && trimmed[trimmed.Length - 1] == '>')
+                    {
+                        return trimmed.Substring(1, trimmed.Length - 2).Trim();
+                    }
+                    return trimmed;
+                }
+            }
+            return null;
+        }
+
+        private static string EscapeXml(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+            return value
+                .Replace("&", "&amp;")
+                .Replace("<", "&lt;")
+                .Replace(">", "&gt;")
+                .Replace("\"", "&quot;")
+                .Replace("'", "&apos;");
         }
 
         private async Task<Stream> DownloadFile(string remoteFilePath, Dictionary<string, string> header, CancellationToken cancellationToken = default)

--- a/WebDAVClient/Helpers/LockResponseParser.cs
+++ b/WebDAVClient/Helpers/LockResponseParser.cs
@@ -1,0 +1,201 @@
+using System;
+using System.IO;
+using System.Xml;
+using WebDAVClient.Model;
+
+namespace WebDAVClient.Helpers
+{
+    /// <summary>
+    /// Parses the <c>&lt;D:lockdiscovery&gt;&lt;D:activelock&gt;</c> subtree
+    /// returned by a successful LOCK or refresh-LOCK response (RFC 4918 §9.10).
+    /// Only the first <c>activelock</c> element is read — this client always
+    /// requests an exclusive write lock, so a successful response carries
+    /// exactly one.
+    /// </summary>
+    internal static class LockResponseParser
+    {
+        private const string c_davNamespace = "DAV:";
+
+        /// <summary>
+        /// Parses a LOCK response body. Returns <c>null</c> if no
+        /// <c>activelock</c> element is present (e.g. an empty body from a
+        /// non-compliant server) — the caller can decide whether to treat
+        /// that as an error.
+        /// </summary>
+        public static LockInfo Parse(Stream stream)
+        {
+            try
+            {
+                using (var reader = XmlReader.Create(stream, ResponseParser.XmlReaderSettings))
+                {
+                    while (reader.Read())
+                    {
+                        if (reader.NodeType == XmlNodeType.Element
+                            && string.Equals(reader.LocalName, "activelock", StringComparison.OrdinalIgnoreCase)
+                            && string.Equals(reader.NamespaceURI, c_davNamespace, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return ReadActiveLock(reader);
+                        }
+                    }
+                }
+            }
+            catch (XmlException)
+            {
+                // Empty / malformed bodies are treated the same as a missing activelock —
+                // callers (LockFile/RefreshLock) decide whether absence is an error.
+                return null;
+            }
+            return null;
+        }
+
+        private static LockInfo ReadActiveLock(XmlReader reader)
+        {
+            var info = new LockInfo();
+            int depth = reader.Depth;
+
+            // All Read* helpers below use ReadSubtree internally, which leaves the parent
+            // reader positioned on the activelock-child's EndElement. That keeps the loop's
+            // reader.Read() correct (advances to the next sibling) without needing a
+            // "previous call already advanced" flag.
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.EndElement
+                    && reader.Depth == depth
+                    && string.Equals(reader.LocalName, "activelock", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                if (reader.NodeType != XmlNodeType.Element)
+                    continue;
+
+                if (!string.Equals(reader.NamespaceURI, c_davNamespace, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var localName = reader.LocalName;
+                if (string.Equals(localName, "locktype", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.LockType = ReadFirstChildElementName(reader);
+                }
+                else if (string.Equals(localName, "lockscope", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.LockScope = ReadFirstChildElementName(reader);
+                }
+                else if (string.Equals(localName, "depth", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.Depth = ReadElementText(reader);
+                }
+                else if (string.Equals(localName, "timeout", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.TimeoutSeconds = ParseTimeout(ReadElementText(reader));
+                }
+                else if (string.Equals(localName, "owner", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.Owner = ReadOwnerInnerXml(reader);
+                }
+                else if (string.Equals(localName, "locktoken", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.Token = ReadHrefChild(reader);
+                }
+                else if (string.Equals(localName, "lockroot", StringComparison.OrdinalIgnoreCase))
+                {
+                    info.LockRoot = ReadHrefChild(reader);
+                }
+            }
+
+            return info;
+        }
+
+        // For elements like <D:locktype><D:write/></D:locktype> — return "write".
+        private static string ReadFirstChildElementName(XmlReader reader)
+        {
+            if (reader.IsEmptyElement)
+                return null;
+
+            using (var sub = reader.ReadSubtree())
+            {
+                sub.MoveToContent();
+                while (sub.Read())
+                {
+                    if (sub.NodeType == XmlNodeType.Element)
+                        return sub.LocalName;
+                }
+            }
+            return null;
+        }
+
+        // For elements like <D:locktoken><D:href>opaquelocktoken:...</D:href></D:locktoken>
+        // — return the inner href text.
+        private static string ReadHrefChild(XmlReader reader)
+        {
+            if (reader.IsEmptyElement)
+                return null;
+
+            using (var sub = reader.ReadSubtree())
+            {
+                sub.MoveToContent();
+                while (sub.Read())
+                {
+                    if (sub.NodeType == XmlNodeType.Element
+                        && string.Equals(sub.LocalName, "href", StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(sub.NamespaceURI, c_davNamespace, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return sub.ReadElementContentAsString().Trim();
+                    }
+                }
+            }
+            return null;
+        }
+
+        // Owner can be free-form XML (e.g. <D:href>...</D:href>) or plain text.
+        // Capture the inner XML so callers can inspect whatever the server returned.
+        private static string ReadOwnerInnerXml(XmlReader reader)
+        {
+            if (reader.IsEmptyElement)
+                return null;
+
+            using (var sub = reader.ReadSubtree())
+            {
+                sub.MoveToContent();
+                return sub.ReadInnerXml().Trim();
+            }
+        }
+
+        // Reads an element's text content. Uses a subtree reader so the parent reader is left
+        // on the element's EndElement (so the caller's outer loop advances normally).
+        private static string ReadElementText(XmlReader reader)
+        {
+            if (reader.IsEmptyElement)
+                return null;
+
+            using (var sub = reader.ReadSubtree())
+            {
+                sub.MoveToContent();
+                return sub.ReadElementContentAsString();
+            }
+        }
+
+        // RFC 4918 §10.7: TimeType = "Second-" 1*DIGIT | "Infinite"
+        // We accept a comma-separated list (the server picks one) and take the first.
+        internal static int? ParseTimeout(string raw)
+        {
+            if (string.IsNullOrWhiteSpace(raw))
+                return null;
+
+            foreach (var part in raw.Split(','))
+            {
+                var token = part.Trim();
+                if (token.Length == 0)
+                    continue;
+                if (string.Equals(token, "Infinite", StringComparison.OrdinalIgnoreCase))
+                    return null;
+                if (token.StartsWith("Second-", StringComparison.OrdinalIgnoreCase)
+                    && int.TryParse(token.Substring("Second-".Length), out var seconds))
+                {
+                    return seconds;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/WebDAVClient/IClient.cs
+++ b/WebDAVClient/IClient.cs
@@ -182,5 +182,86 @@ namespace WebDAVClient
         /// <returns>True if the file was copied successfully. False otherwise.</returns>
         /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status.</exception>
         Task<bool> CopyFile(string srcFilePath, string dstFilePath, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Acquire an exclusive write lock on a file (RFC 4918 §9.10, <c>Depth: 0</c>).
+        /// </summary>
+        /// <param name="filePath">Path and filename of the file on the server.</param>
+        /// <param name="timeoutSeconds">
+        /// Requested lock timeout in seconds (sent as <c>Timeout: Second-{n}</c>). The server may grant a shorter
+        /// timeout — inspect <see cref="LockInfo.TimeoutSeconds"/> on the returned value. Must be greater than zero.
+        /// </param>
+        /// <param name="owner">
+        /// Free-form identifier for the lock owner, embedded in the request body's <c>&lt;D:owner&gt;</c> element so
+        /// that other clients (and humans inspecting the lock) can identify who holds it. When <c>null</c>, defaults
+        /// to <c>WebDAVClient</c>.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="LockInfo"/> describing the granted lock; <see cref="LockInfo.Token"/> is the value to pass to <see cref="UnlockFile"/> / <see cref="RefreshLock"/>.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server refuses the lock (e.g. <c>423 Locked</c>) or returns any other non-success status.</exception>
+        Task<LockInfo> LockFile(string filePath, int timeoutSeconds = 600, string owner = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Acquire an exclusive write lock on a folder (RFC 4918 §9.10, <c>Depth: infinity</c>) — locks the
+        /// collection and all of its members.
+        /// </summary>
+        /// <param name="folderPath">Path of the folder on the server.</param>
+        /// <param name="timeoutSeconds">
+        /// Requested lock timeout in seconds. The server may grant a shorter timeout. Must be greater than zero.
+        /// </param>
+        /// <param name="owner">
+        /// Free-form identifier for the lock owner. Defaults to <c>WebDAVClient</c> when <c>null</c>.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="LockInfo"/> describing the granted lock.</returns>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server refuses the lock or returns a non-success status. <c>207 Multi-Status</c> on a depth-infinity LOCK indicates a partial failure (RFC 4918 §9.10.6) and is also surfaced as <c>WebDAVException</c>.</exception>
+        Task<LockInfo> LockFolder(string folderPath, int timeoutSeconds = 600, string owner = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Release a lock previously acquired with <see cref="LockFile"/> (RFC 4918 §9.11).
+        /// </summary>
+        /// <param name="filePath">Path and filename of the file on the server.</param>
+        /// <param name="lockToken">
+        /// The lock token returned by <see cref="LockFile"/> (i.e. <see cref="LockInfo.Token"/>). May be passed in
+        /// either bare form (<c>opaquelocktoken:...</c>) or wrapped in angle brackets (<c>&lt;opaquelocktoken:...&gt;</c>);
+        /// the client normalizes it before sending the <c>Lock-Token</c> header.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <exception cref="System.ArgumentException">Thrown when <paramref name="lockToken"/> is <c>null</c>, empty, or malformed.</exception>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-<c>204</c> status (e.g. <c>409 Conflict</c> when the token does not match the lock).</exception>
+        Task UnlockFile(string filePath, string lockToken, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Release a lock previously acquired with <see cref="LockFolder"/> (RFC 4918 §9.11).
+        /// </summary>
+        /// <param name="folderPath">Path of the folder on the server.</param>
+        /// <param name="lockToken">
+        /// The lock token returned by <see cref="LockFolder"/>. Bare or angle-bracketed forms are both accepted.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <exception cref="System.ArgumentException">Thrown when <paramref name="lockToken"/> is <c>null</c>, empty, or malformed.</exception>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-<c>204</c> status.</exception>
+        Task UnlockFolder(string folderPath, string lockToken, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Refresh an existing lock by sending a body-less LOCK request with the <c>If</c> header carrying the
+        /// current lock token (RFC 4918 §9.10.2). Use this before <c>TimeoutSeconds</c> elapses to keep the lock alive.
+        /// </summary>
+        /// <param name="path">Path of the locked file or folder on the server.</param>
+        /// <param name="lockToken">
+        /// The current lock token, in either bare or angle-bracketed form.
+        /// </param>
+        /// <param name="timeoutSeconds">
+        /// Requested new timeout in seconds. The server may grant a shorter value. Must be greater than zero.
+        /// </param>
+        /// <param name="cancellationToken">Token used to cancel the asynchronous operation.</param>
+        /// <returns>
+        /// A <see cref="LockInfo"/> reflecting the refreshed lock state. If the server's response carries no
+        /// <c>activelock</c> body (some servers do this), the returned <see cref="LockInfo.Token"/> is the
+        /// caller-supplied token and the other fields will be <c>null</c>.
+        /// </returns>
+        /// <exception cref="System.ArgumentException">Thrown when <paramref name="lockToken"/> is <c>null</c>, empty, or malformed.</exception>
+        /// <exception cref="WebDAVClient.Helpers.WebDAVException">Thrown when the server returns a non-success status (e.g. <c>412 Precondition Failed</c> when the token no longer matches an active lock).</exception>
+        Task<LockInfo> RefreshLock(string path, string lockToken, int timeoutSeconds = 600, CancellationToken cancellationToken = default);
     }
 }

--- a/WebDAVClient/Model/LockInfo.cs
+++ b/WebDAVClient/Model/LockInfo.cs
@@ -1,0 +1,61 @@
+namespace WebDAVClient.Model
+{
+    /// <summary>
+    /// Information about a WebDAV lock returned by <see cref="IClient.LockFile"/>,
+    /// <see cref="IClient.LockFolder"/>, and <see cref="IClient.RefreshLock"/>.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors the contents of the <c>&lt;D:activelock&gt;</c> element described in
+    /// RFC 4918 §14.1 (with a copy of the canonical lock token from the
+    /// <c>Lock-Token</c> response header per §10.5).
+    /// </remarks>
+    public class LockInfo
+    {
+        /// <summary>
+        /// The opaque lock token URI returned by the server, in bare form
+        /// (no surrounding <c>&lt;&gt;</c>). This is the value to pass back to
+        /// <see cref="IClient.UnlockFile"/> / <see cref="IClient.UnlockFolder"/> /
+        /// <see cref="IClient.RefreshLock"/>; the client wraps it in the correct
+        /// header syntax automatically.
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// Free-form text content of the <c>&lt;D:owner&gt;</c> element as the
+        /// server returned it. May be <c>null</c> when the server did not
+        /// echo an owner.
+        /// </summary>
+        public string Owner { get; set; }
+
+        /// <summary>
+        /// Lock type — typically <c>"write"</c> (the only value defined by RFC 4918).
+        /// </summary>
+        public string LockType { get; set; }
+
+        /// <summary>
+        /// Lock scope — <c>"exclusive"</c> or <c>"shared"</c>. This client always
+        /// requests <c>exclusive</c>.
+        /// </summary>
+        public string LockScope { get; set; }
+
+        /// <summary>
+        /// Depth at which the lock applies — <c>"0"</c> for a single resource
+        /// or <c>"infinity"</c> for a collection lock.
+        /// </summary>
+        public string Depth { get; set; }
+
+        /// <summary>
+        /// Lock timeout in seconds, or <c>null</c> when the server returned
+        /// <c>Infinite</c>. Note that the server may grant a different timeout
+        /// than was requested.
+        /// </summary>
+        public int? TimeoutSeconds { get; set; }
+
+        /// <summary>
+        /// The href to which the lock actually applies — i.e. the value of
+        /// <c>&lt;D:lockroot&gt;&lt;D:href&gt;</c> in the response. Useful when
+        /// locking a member of a depth-infinity collection lock.
+        /// </summary>
+        public string LockRoot { get; set; }
+    }
+}

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -5,7 +5,7 @@
     <Configurations>Debug;Release;Release-Unsigned</Configurations>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>WebDAVClient</PackageId>
-    <Version>2.5.5</Version>
+    <Version>2.7.0</Version>
     <Description>WebDAVClient is a strongly-typed, async, C# client for WebDAV.</Description>
     <Authors>Sagui Itay</Authors>
     <Company></Company>
@@ -13,16 +13,9 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Feature: WebDAV LOCK / UNLOCK support per RFC 4918 §9.10–9.11. New IClient methods LockFile / LockFolder / UnlockFile / UnlockFolder / RefreshLock return a strongly-typed LockInfo (token, owner, type/scope, depth, timeout, lock-root). Lock tokens are normalized so callers can pass them either bare (opaquelocktoken:...) or angle-bracket-wrapped.
-* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
-* Bug fix / performance: List() now compares the parent-folder URL using StringComparison.OrdinalIgnoreCase instead of CurrentCultureIgnoreCase. URLs are not locale-sensitive, so this avoids both the slower culture-aware comparison and potential wrong results in locales like Turkish (the dotted/dotless 'I' issue).
-* Performance: CustomHeaders are no longer copied into a per-call merged dictionary. HttpRequest/HttpUploadRequest now iterate CustomHeaders directly, eliminating one Dictionary allocation and one extra iteration per request.
-* Security: ResponseParser's XmlReaderSettings now explicitly sets DtdProcessing = Prohibit and XmlResolver = null to harden against XXE (XML External Entity) attacks from malicious or compromised WebDAV servers. Defends against arbitrary file disclosure, SSRF, and "billion laughs" denial-of-service on runtimes (e.g. Mono) where the .NET defaults may differ.
-* Security / bug fix: ServerCertificateValidationCallback was previously a dead property — never wired to the underlying HttpClientHandler — so users relying on it for certificate pinning, custom CA trust, or self-signed cert acceptance were silently ignored. The (ICredentials, TimeSpan?, IWebProxy) constructor now wires the callback into HttpClientHandler.ServerCertificateCustomValidationCallback via a closure that resolves the property lazily on each handshake, so callers can still assign or reassign it after construction. When unset, the wired closure defers to the platform's default trust decision (errors == None) instead of denying. Has no effect on Clients constructed with a caller-supplied HttpClient/IHttpClientWrapper — configure the callback on your own handler in that case.
-* Security: BuildServerUrl now validates that any absolute URI it accepts (either an absolute path argument or an absolute server-resolved base path) belongs to the configured Server host. Previously a malicious or compromised WebDAV server could return absolute &lt;href&gt; values pointing at a different host (e.g. internal infrastructure); if those hrefs were passed back into operations like List/Download/DeleteFolder the client would issue requests to that arbitrary host, enabling SSRF and host-confusion attacks. Mismatched hosts now throw InvalidOperationException with a descriptive message. Host comparison is case-insensitive (RFC 3986 §3.2.2).
-* Security: CustomHeaders entries are now validated for CR/LF characters in both the header name and value before being added to outgoing requests. Previously a CR/LF in a CustomHeaders value could be used for HTTP header injection when callers populated CustomHeaders from untrusted input. Modern .NET's HttpHeaders.Add already throws FormatException for CR/LF in values, but the protection was runtime-dependent and gave a generic error; we now throw ArgumentException with a clear message identifying the offending header consistently across runtimes.</PackageReleaseNotes>
-    <AssemblyVersion>2.5.5.0</AssemblyVersion>
-    <FileVersion>2.5.5.0</FileVersion>
+    <PackageReleaseNotes>* Feature: WebDAV LOCK / UNLOCK support per RFC 4918 §9.10–9.11. New IClient methods LockFile / LockFolder / UnlockFile / UnlockFolder / RefreshLock return a strongly-typed LockInfo (token, owner, type/scope, depth, timeout, lock-root). Lock tokens are normalized so callers can pass them either bare (opaquelocktoken:...) or angle-bracket-wrapped.</PackageReleaseNotes>
+    <AssemblyVersion>2.7.0.0</AssemblyVersion>
+    <FileVersion>2.7.0.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/WebDAVClient/WebDAVClient.csproj
+++ b/WebDAVClient/WebDAVClient.csproj
@@ -13,7 +13,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright © 2026 Sagui Itay</Copyright>
     <PackageTags>WebDAV HttpClient c#</PackageTags>
-    <PackageReleaseNotes>* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
+    <PackageReleaseNotes>* Feature: WebDAV LOCK / UNLOCK support per RFC 4918 §9.10–9.11. New IClient methods LockFile / LockFolder / UnlockFile / UnlockFolder / RefreshLock return a strongly-typed LockInfo (token, owner, type/scope, depth, timeout, lock-root). Lock tokens are normalized so callers can pass them either bare (opaquelocktoken:...) or angle-bracket-wrapped.
+* Performance: HttpRequest and HttpUploadRequest no longer perform a redundant dictionary lookup per header. The header dictionary is now iterated as KeyValuePair entries instead of iterating Keys and indexing back into the dictionary.
 * Bug fix / performance: List() now compares the parent-folder URL using StringComparison.OrdinalIgnoreCase instead of CurrentCultureIgnoreCase. URLs are not locale-sensitive, so this avoids both the slower culture-aware comparison and potential wrong results in locales like Turkish (the dotted/dotless 'I' issue).
 * Performance: CustomHeaders are no longer copied into a per-call merged dictionary. HttpRequest/HttpUploadRequest now iterate CustomHeaders directly, eliminating one Dictionary allocation and one extra iteration per request.
 * Security: ResponseParser's XmlReaderSettings now explicitly sets DtdProcessing = Prohibit and XmlResolver = null to harden against XXE (XML External Entity) attacks from malicious or compromised WebDAV servers. Defends against arbitrary file disclosure, SSRF, and "billion laughs" denial-of-service on runtimes (e.g. Mono) where the .NET defaults may differ.


### PR DESCRIPTION
## Issue

> 🔴 LOCK / UNLOCK (RFC 4918, §9.10–9.11) — Most Critical
> The library has no LOCK or UNLOCK HTTP method support. These are core WebDAV operations required for: preventing concurrent writes to the same resource, collaborative editing workflows (CalDAV, CardDAV, Office/SharePoint-style clients all depend on this), and any write operation on a server that requires a lock token in the `If` header before accepting a PUT/DELETE/MOVE.

This PR adds first-class LOCK / UNLOCK support per RFC 4918 §9.10–9.11.

## Fix

New methods on `IClient` / `Client`:

- `LockFile` / `LockFolder` — acquire an exclusive write lock. Configurable `owner` (XML-escaped on the wire) and `timeoutSeconds` (validated > 0). Folder lock defaults to `Depth: infinity`; file lock to `Depth: 0`.
- `UnlockFile` / `UnlockFolder` — release a previously acquired lock. Token can be passed bare (`opaquelocktoken:abc`) or angle-bracket-wrapped (`<opaquelocktoken:abc>`); the client emits `Lock-Token: <…>` per RFC.
- `RefreshLock` — extend an existing lock without re-locking the resource. Sends an empty-body LOCK with `If: (<token>)`. If the server omits `<activelock>` from the response (some implementations do on refresh), the caller's token is preserved on the returned `LockInfo`.

All five return a strongly-typed `LockInfo` (token, owner, lock type/scope, depth, timeout, lock-root).

Implementation notes:

- `207 Multi-Status` on LOCK is treated as failure (partial lock per RFC §9.10.6); `UNLOCK` accepts only `204 No Content`. Other failures surface as `WebDAVException` (`409` as `WebDAVConflictException`) consistent with the rest of the client.
- Lock tokens are normalized via a single internal helper that strips outer angle brackets and rejects null/empty/CR/LF/embedded brackets — defense against header injection.
- `LockResponseParser` reuses the existing XXE-hardened `XmlReaderSettings` from `ResponseParser` (`DtdProcessing = Prohibit`, `XmlResolver = null`).
- The legacy `Client` constructor and existing public surface are unchanged.

## Tests

17 new tests in `WebDAVClient.UnitTests/ClientLockTests.cs` covering:

- Request shape: HTTP method (`LOCK` / `UNLOCK`), headers (`Depth`, `Timeout`, `Lock-Token`, `If`), XML body structure, owner XML-escaping.
- Response parsing: full `activelock` body, missing fields, empty body fallback on refresh.
- Token normalization: bare, angle-bracket-wrapped, rejection of CR/LF and embedded brackets.
- Status codes: `200` / `201` / `204` success paths; `207` / `409` / `423` failure paths mapping to the right exception types.

Full suite: **93 / 93 passing** on `net8.0` and `net10.0`.

## Other changes

- `README.md` and `WebDAVClient.csproj` `<PackageReleaseNotes>` updated with a `2.6.0` bullet describing the new LOCK/UNLOCK surface.
- **No version bump** — accumulates on `version-2.6`.
