### PR TITLE
Refresh README and ROADMAP for the 2.7.0 feature surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ WebDAVClient is available as a [NuGet package](https://www.nuget.org/packages/We
 * Fully support Async/Await
 * Strong-typed
 * Implemented using HttpClient, which means support for extendibility such as throttling and monitoring
-* Supports Unauthenticated or Windows Authentication-based access
+* Authentication: unauthenticated, Windows / Basic / Digest (via `ICredentials`), and Bearer / OAuth 2.0 (via static token or async refreshable provider)
 * Supports custom Certificate validation
 * Supports the full WebDAV API:
   * Retrieving files & folders
-  * Listing items in a folder
+  * Listing items in a folder (`<allprop/>`, targeted `<prop>`, and `<propname/>` PROPFIND variants)
   * Creating & deleting folders
   * Downloading & uploading files
   * Downloading & uploading partial content
-  * Moving & copying files and folders
+  * Moving & copying files and folders (with the `Overwrite` header and optional destination lock-token)
+  * Locking & unlocking resources (LOCK / UNLOCK / RefreshLock) with a strongly-typed `LockInfo`
+  * Setting & removing custom (dead) properties via PROPPATCH
+  * Discovering server capabilities via OPTIONS (DAV compliance classes + allowed methods)
+  * Submitting WebDAV lock tokens through the `If` header on PUT / DELETE / MOVE / COPY
 
 ## Release Notes
 
@@ -130,6 +134,9 @@ using IClient client = new Client(
 // (3) ...or supply your own HttpClient (e.g. for IHttpClientFactory / DI scenarios)
 // using IClient client = new Client(myHttpClient);
 
+// (4) ...or Bearer / OAuth 2.0 — see "What's new in 2.7.0" below for refresh-aware variant
+// using IClient client = new Client("eyJ0eXAiOiJKV1Qi...");
+
 // Set basic information for the WebDAV provider
 client.Server = "https://dav.example.com/";
 client.BasePath = "/dav/";
@@ -186,6 +193,94 @@ await client.CopyFolder(folder.Href, "/" + tempFolderName + "-copy/", cancellati
 // Delete created folder
 var folderCreated = await client.GetFolder("/" + tempFolderName, cancellationToken: token);
 await client.DeleteFolder(folderCreated.Href, cancellationToken: token);
+```
+
+## What's new in 2.7.0
+
+### Bearer token / OAuth 2.0 authentication
+
+```csharp
+// Static token (Nextcloud app-password, long-lived service token, …)
+using IClient client = new Client("eyJ0eXAiOiJKV1Qi...");
+
+// Async, refreshable token provider (Azure AD / MSAL / IdentityModel / custom)
+using IClient client = new Client(async ct => await tokenSource.GetTokenAsync(ct));
+```
+
+Returning `null` / empty from the provider omits the `Authorization` header (the server then naturally returns `401`). The handler is also exposed publicly as `WebDAVClient.Authentication.BearerTokenAuthenticationHandler` if you need to compose it into your own `HttpClient` pipeline.
+
+### Discover server capabilities (OPTIONS)
+
+```csharp
+var options = await client.GetServerOptions("/dav/", cancellationToken: token);
+if (!options.IsWebDavServer)
+    throw new InvalidOperationException("Endpoint is not a WebDAV server");
+
+bool supportsLock = options.IsClass2 && options.SupportsMethod("LOCK");
+```
+
+### Lock / unlock and refresh
+
+```csharp
+// Take an exclusive write lock on a file (default timeout: 600 seconds)
+var info = await client.LockFile("/dav/report.docx", owner: "alice", cancellationToken: token);
+
+// Use the lock token on subsequent writes via the If header
+using (var fs = File.OpenRead(localPath))
+    await client.Upload("/dav/", fs, "report.docx", lockToken: info.Token, cancellationToken: token);
+
+// Extend / release the lock
+await client.RefreshLock("/dav/report.docx", info.Token, timeoutSeconds: 600, cancellationToken: token);
+await client.UnlockFile("/dav/report.docx", info.Token, cancellationToken: token);
+```
+
+`LockInfo.Token` is accepted in either bare (`opaquelocktoken:abc`) or `<opaquelocktoken:abc>` form everywhere it's used.
+
+### Set / remove custom properties (PROPPATCH)
+
+```csharp
+// Set a custom dead property in your own namespace (the DAV: namespace is reserved for live properties and is rejected client-side)
+await client.SetProperty("/dav/report.docx", "author", "https://example.com/ns", "Alice", token);
+
+// Remove it later
+await client.RemoveProperty("/dav/report.docx", "author", "https://example.com/ns", token);
+```
+
+### Targeted PROPFIND — `<prop>` and `<propname/>`
+
+```csharp
+// Ask only for the properties you need (saves bandwidth on large directories)
+var props = new[]
+{
+    new PropertyName("getetag",          "DAV:"),
+    new PropertyName("getcontentlength", "DAV:"),
+    new PropertyName("author",           "https://example.com/ns"),
+};
+var items = await client.List("/dav/", depth: 1, properties: props, cancellationToken: token);
+
+foreach (var item in items)
+{
+    // Standard DAV: live properties light up on Item directly (Etag, ContentLength, …)
+    // Custom properties land in FoundProperties / NotFoundProperties.
+    var author = item.FoundProperties?.FirstOrDefault(p => p.Name.LocalName == "author");
+}
+
+// Discover what properties a resource exposes
+var names = await client.GetFilePropertyNames("/dav/report.docx", cancellationToken: token);
+foreach (var n in names.AvailablePropertyNames)
+    Console.WriteLine($"{n.Namespace}:{n.LocalName}");
+```
+
+### Lock-token-aware writes (If header)
+
+```csharp
+// PUT / DELETE / MOVE / COPY now accept the relevant lock tokens, so locked-resource servers stop rejecting the request with 423 Locked.
+await client.DeleteFile("/dav/report.docx", lockToken: info.Token, cancellationToken: token);
+await client.MoveFile("/dav/old.txt", "/dav/new.txt",
+    sourceLockToken: srcToken, destinationLockToken: dstToken, cancellationToken: token);
+
+// Opt out of clobbering an existing destination (sends Overwrite: F → server returns 412 Precondition Failed)
+await client.CopyFile("/dav/a.txt", "/dav/b.txt", overwrite: false, cancellationToken: token);
 ```
 
 ## Contact

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,8 @@ This document outlines the recommended improvements and missing features for the
 **Priority: High**
 **Target: v3.0.0**
 
+> **Status update (2.7.0)**: Bearer token / OAuth 2.0 authentication has shipped via two new `Client` constructor overloads (static token + async refreshable provider) backed by the public `WebDAVClient.Authentication.BearerTokenAuthenticationHandler`. The remaining items below — `TokenCredential` / `ApiKeyCredential` integration, `AuthenticationOptions`, and the fluent `ClientBuilder` — are still planned for v3.0.0.
+
 The current implementation only supports basic authentication and Windows authentication. We need to add support for modern authentication methods using established .NET patterns:
 
 #### Modern Authentication Patterns
@@ -153,6 +155,8 @@ var client = ClientBuilder.Create()
 **Priority: High**
 **Target: v3.0.0**
 
+> **Status update (2.7.0)**: Shipped. `IClient` now exposes `LockFile` / `LockFolder` / `UnlockFile` / `UnlockFolder` / `RefreshLock` returning a strongly-typed `LockInfo`, and the `If` lock-token header is sent on PUT / DELETE / MOVE / COPY when callers pass the new optional `lockToken` (and source / destination variants) parameters.
+
 Critical WebDAV operations that are currently missing:
 
 #### New Methods to Implement
@@ -181,6 +185,8 @@ public class LockInfo
 ### 3. WebDAV Properties Management (PROPPATCH)
 **Priority: Medium**
 **Target: v3.1.0**
+
+> **Status update (2.7.0)**: Shipped. `IClient.SetProperty(path, name, namespace, value)` and `IClient.RemoveProperty(path, name, namespace)` are available; targeted PROPFIND via `<prop>` / `<propname/>` also shipped (see the new `List` / `GetFolder` / `GetFile` overloads taking `IEnumerable<PropertyName>` and the `*PropertyNames` methods).
 
 The client can read properties but cannot set or manage custom properties:
 
@@ -316,6 +322,8 @@ public class WebDAVException : Exception
 ### 11. Health Checking and Diagnostics
 **Priority: Medium**
 **Target: v3.0.0**
+
+> **Status update (2.7.0)**: `GetServerCapabilities` is partially covered by the new `IClient.GetServerOptions(path, ct)` returning a strongly-typed `ServerOptions` (DAV compliance classes + allowed methods). The full `CheckHealth` / `GetConnectionInfo` surface below remains planned.
 
 Add server connectivity and health monitoring:
 


### PR DESCRIPTION
### Issue

The 2.7.0 work landed nine new feature commits on `version-2.7` (LOCK / UNLOCK, PROPPATCH, OPTIONS, granular PROPFIND, `If` lock-token submission, `Overwrite` header, `Depth: infinity` on DELETE, Bearer / OAuth 2.0 auth, the helpers refactor) but the project documentation never caught up:

- `README.md` **Features** list still claimed the only authentication option was *"Unauthenticated or Windows Authentication-based access"* — no mention of Basic, Digest, or Bearer / OAuth 2.0; no mention of LOCK / UNLOCK, PROPPATCH, OPTIONS, granular PROPFIND, or lock-token-aware writes.
- `README.md` **Usage** section showed zero examples for any of the new APIs — the only documentation of them was the (deliberately terse) `PackageReleaseNotes` bullets.
- `ROADMAP.md` still listed *"Advanced Authentication Support"*, *"WebDAV Lock/Unlock Operations"*, *"WebDAV Properties Management (PROPPATCH)"* and the server-capabilities portion of *"Health Checking and Diagnostics"* as planned for v3.0 / v3.1, even though they all (or in some cases, partially) shipped in 2.7.0.

### Fix

- Updated the README **Features** bullet list to reflect the actual 2.7.0 surface (auth options, lock/unlock, PROPPATCH, OPTIONS / capability discovery, lock-token-aware writes, `<prop>` / `<propname/>` PROPFIND variants, `Overwrite` header).
- Added a new **"What's new in 2.7.0"** subsection under Usage with short copy-pasteable snippets for: Bearer-token constructors, `GetServerOptions`, `LockFile` / `RefreshLock` / `UnlockFile`, `SetProperty` / `RemoveProperty`, targeted PROPFIND with `PropertyName` and `GetFilePropertyNames`, and the new `lockToken` / `overwrite` parameters on writes.
- Added the Bearer-token constructor to the existing constructor enumeration in the original Usage block (with a pointer down to the refresh-aware variant).
- Annotated each ROADMAP item that shipped (or partially shipped) in 2.7.0 with a `> Status update (2.7.0)` note describing what's done and what remains. The forward-looking sections themselves are left intact for the v3.0 work.

### Tests

None — docs-only change, no code touched.

### Other changes

- No version bump — accumulates on `version-2.7`.
- `PackageReleaseNotes` is intentionally not extended; the new prose lives in the body of `README.md` (under the existing 2.7.0 release-notes bullets), not in NuGet's compact metadata.